### PR TITLE
fix: Fix NPE when replacement.iReplacement is null

### DIFF
--- a/editor/src/main/java/io/github/rosemoe/sora/widget/CodeEditor.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/CodeEditor.java
@@ -4483,13 +4483,13 @@ public class CodeEditor extends View implements ContentListener, TextAnalyzer.Ca
                         if (text.length() == 1 && isSymbolCompletionEnabled()) {
                             replacement = mLanguageSymbolPairs.getCompletion(text.charAt(0));
                         }
-                        if (replacement == null || replacement == SymbolPairMatch.Replacement.NO_REPLACEMENT
+                        if (replacement == null || replacement.iReplacement == null || replacement == SymbolPairMatch.Replacement.NO_REPLACEMENT
                                 || !replacement.shouldDoReplace(getText()) || replacement.iReplacement.getAutoSurroundPair() == null) {
                             getCursor().onCommitText(text);
                             notifyExternalCursorChange();
                         } else {
                             String[] autoSurroundPair;
-                            if (getCursor().isSelected() && (autoSurroundPair = replacement.iReplacement.getAutoSurroundPair()) != null) {
+                            if (getCursor().isSelected() && replacement.iReplacement != null && (autoSurroundPair = replacement.iReplacement.getAutoSurroundPair()) != null) {
                                 getText().beginBatchEdit();
                                 //insert left
                                 getText().insert(getCursor().getLeftLine(), getCursor().getLeftColumn(), autoSurroundPair[0]);

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/EditorInputConnection.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/EditorInputConnection.java
@@ -238,12 +238,12 @@ class EditorInputConnection extends BaseInputConnection {
         }
         // newCursorPosition ignored
         // Call onCommitText() can make auto indent and delete text selected automatically
-        if (replacement == null || replacement == SymbolPairMatch.Replacement.NO_REPLACEMENT
+        if (replacement == null || replacement.iReplacement == null || replacement == SymbolPairMatch.Replacement.NO_REPLACEMENT
                 || !replacement.shouldDoReplace(mEditor.getText()) || replacement.iReplacement.getAutoSurroundPair() == null) {
             getCursor().onCommitText(text, applyAutoIndent);
         } else {
             String[] autoSurroundPair;
-            if (getCursor().isSelected() && (autoSurroundPair = replacement.iReplacement.getAutoSurroundPair()) != null) {
+            if (getCursor().isSelected() && replacement.iReplacement != null && (autoSurroundPair = replacement.iReplacement.getAutoSurroundPair()) != null) {
                 mEditor.getText().beginBatchEdit();
                 //insert left
                 mEditor.getText().insert(getCursor().getLeftLine(), getCursor().getLeftColumn(), autoSurroundPair[0]);


### PR DESCRIPTION
Fixes the NPE that's thrown when replacement.iReplacement is null, by adding null checks.