### PR TITLE
Fixed flickering of completion window when invoked multiple times.

### DIFF
--- a/editor/src/main/java/io/github/rosemoe/sora/lang/completion/CompletionPublisher.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/lang/completion/CompletionPublisher.java
@@ -207,6 +207,7 @@ public class CompletionPublisher {
         handler.post(() -> {
             // Lock the candidate list accordingly
             if (invalid) {
+                callback.run();
                 return;
             }
             var locked = false;
@@ -220,6 +221,7 @@ public class CompletionPublisher {
             if (locked) {
                 try {
                     if (candidates.size() == 0) {
+                        callback.run();
                         return;
                     }
                     final var comparator = this.comparator;

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/component/EditorAutoCompletion.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/component/EditorAutoCompletion.java
@@ -26,6 +26,8 @@ package io.github.rosemoe.sora.widget.component;
 import android.content.Context;
 import android.os.Bundle;
 import android.util.Log;
+import android.widget.Adapter;
+import android.widget.AdapterView;
 
 import androidx.annotation.NonNull;
 
@@ -70,8 +72,8 @@ public class EditorAutoCompletion extends EditorPopupWindow implements EditorBui
     public EditorAutoCompletion(CodeEditor editor) {
         super(editor, FEATURE_HIDE_WHEN_FAST_SCROLL);
         mEditor = editor;
-        setLayout(new DefaultCompletionLayout());
         mAdapter = new DefaultCompletionItemAdapter();
+        setLayout(new DefaultCompletionLayout());
     }
 
     @SuppressWarnings("unchecked")
@@ -103,6 +105,8 @@ public class EditorAutoCompletion extends EditorPopupWindow implements EditorBui
         if (adapter == null) {
             mAdapter = new DefaultCompletionItemAdapter();
         }
+
+        mLayout.getCompletionList();
     }
 
     @Override
@@ -305,8 +309,6 @@ public class EditorAutoCompletion extends EditorPopupWindow implements EditorBui
             }
         }, mEditor.getEditorLanguage().getInterruptionLevel());
         mAdapter.attachValues(this, publisher.getItems());
-        var adpView = mLayout.getCompletionList();
-        adpView.setAdapter(mAdapter);
         mThread = new CompletionThread(mRequestTime, publisher);
         setLoading(true);
         mThread.start();

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/component/EditorCompletionAdapter.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/component/EditorCompletionAdapter.java
@@ -50,7 +50,6 @@ public abstract class EditorCompletionAdapter extends BaseAdapter implements Ada
     public void attachValues(EditorAutoCompletion window, List<CompletionItem> items) {
         mWindow = window;
         mItems = items;
-        notifyDataSetInvalidated();
     }
 
     @Override


### PR DESCRIPTION
The adapter was being refreshed three times when requireCompletion() is invoked.

The first refresh is with the call to `mAdapter#setValues()`, The second refresh is the call to `mAdapterView#setAdapter()` and the third refresh is on the callback at CompletionPublisher.

This refreshes causes the flickering of the completion window, to solve this I made the list refresh only after the items have arrived.