### PR TITLE
Fix: Crash while performing 'Replace all' action

### DIFF
--- a/editor/src/main/java/io/github/rosemoe/sora/widget/CodeEditor.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/CodeEditor.java
@@ -2116,11 +2116,11 @@ public class CodeEditor extends View implements ContentListener, StyleReceiver, 
                                 .setNegativeButton(R.string.cancel, null)
                                 .setPositiveButton(R.string.replace, (dialog, which) -> {
                                     if (replaceAll) {
-                                        getSearcher().replaceAll(et.getText().toString());
+                                        getSearcher().replaceAll(et.getText().toString(), am::finish);
                                     } else {
                                         getSearcher().replaceThis(et.getText().toString());
+                                        am.finish();
                                     }
-                                    am.finish();
                                     dialog.dismiss();
                                 })
                                 .show();

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/EditorSearcher.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/EditorSearcher.java
@@ -27,6 +27,7 @@ import android.app.ProgressDialog;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import java.util.regex.Pattern;
 
@@ -216,7 +217,11 @@ public class EditorSearcher {
         }
     }
 
-    public void replaceAll(@NonNull String replacement) {
+    public void replaceAll (@NonNull String replacement) {
+        replaceAll (replacement, null);
+    }
+
+    public void replaceAll(@NonNull String replacement, @Nullable final Runnable whenFinished) {
         checkState();
         if (!isResultValid()) {
             Toast.makeText(mEditor.getContext(), "Editor is still preparing", Toast.LENGTH_SHORT).show();
@@ -252,6 +257,10 @@ public class EditorSearcher {
                     mEditor.getText().replace(0, 0, mEditor.getLineCount() - 1, mEditor.getText().getColumnCount(mEditor.getLineCount() - 1), sb);
                     mEditor.setSelectionAround(pos.line, pos.column);
                     dialog.dismiss();
+    
+                    if (whenFinished != null) {
+                        whenFinished.run ();
+                    }
                 });
             } catch (Exception e) {
                 mEditor.post(() -> {


### PR DESCRIPTION
While [performing replace all action](https://github.com/Rosemoe/sora-editor/blob/ffe32753b29802c399069a73e3ae3a7c36e1fbd6/editor/src/main/java/io/github/rosemoe/sora/widget/CodeEditor.java#L2118), the [editor finishes the current action mode](https://github.com/Rosemoe/sora-editor/blob/ffe32753b29802c399069a73e3ae3a7c36e1fbd6/editor/src/main/java/io/github/rosemoe/sora/widget/CodeEditor.java#L2123) which in turn calls [`EditorSearcher.stopSearch()`](https://github.com/Rosemoe/sora-editor/blob/ffe32753b29802c399069a73e3ae3a7c36e1fbd6/editor/src/main/java/io/github/rosemoe/sora/widget/CodeEditor.java#L2135). When the stop method is called, the searcher makes the [`mOptions` field null](https://github.com/Rosemoe/sora-editor/blob/ffe32753b29802c399069a73e3ae3a7c36e1fbd6/editor/src/main/java/io/github/rosemoe/sora/widget/EditorSearcher.java#L101). But the thread started by the replace all action tries to [access members of `mOptions`](https://github.com/Rosemoe/sora-editor/blob/ffe32753b29802c399069a73e3ae3a7c36e1fbd6/editor/src/main/java/io/github/rosemoe/sora/widget/EditorSearcher.java#L231) which results in the exception.