### PR TITLE
Provide different `CursorAnimator` implementations

### DIFF
--- a/app/src/main/java/io/github/rosemoe/sora/app/MainActivity.kt
+++ b/app/src/main/java/io/github/rosemoe/sora/app/MainActivity.kt
@@ -49,10 +49,7 @@ import io.github.rosemoe.sora.text.ContentCreator
 import io.github.rosemoe.sora.textmate.core.internal.theme.reader.ThemeReader
 import io.github.rosemoe.sora.textmate.languageconfiguration.internal.supports.CharacterPair
 import io.github.rosemoe.sora.utils.CrashHandler
-import io.github.rosemoe.sora.widget.CodeEditor
-import io.github.rosemoe.sora.widget.EditorSearcher
-import io.github.rosemoe.sora.widget.FadeCursorAnimator
-import io.github.rosemoe.sora.widget.SymbolInputView
+import io.github.rosemoe.sora.widget.*
 import io.github.rosemoe.sora.widget.component.Magnifier
 import io.github.rosemoe.sora.widget.schemes.*
 import io.github.rosemoe.sorakt.subscribeEvent
@@ -123,7 +120,7 @@ class MainActivity : AppCompatActivity() {
         }
 
         // Custom cursor animator
-        binding.editor.cursorAnimator = FadeCursorAnimator(binding.editor)
+        binding.editor.cursorAnimator = ScaleCursorAnimator(binding.editor)
 
         val editor = binding.editor
         var editorColorScheme = editor.colorScheme

--- a/app/src/main/java/io/github/rosemoe/sora/app/MainActivity.kt
+++ b/app/src/main/java/io/github/rosemoe/sora/app/MainActivity.kt
@@ -51,6 +51,7 @@ import io.github.rosemoe.sora.textmate.languageconfiguration.internal.supports.C
 import io.github.rosemoe.sora.utils.CrashHandler
 import io.github.rosemoe.sora.widget.CodeEditor
 import io.github.rosemoe.sora.widget.EditorSearcher
+import io.github.rosemoe.sora.widget.FadeCursorAnimator
 import io.github.rosemoe.sora.widget.SymbolInputView
 import io.github.rosemoe.sora.widget.component.Magnifier
 import io.github.rosemoe.sora.widget.schemes.*
@@ -120,6 +121,9 @@ class MainActivity : AppCompatActivity() {
                 )
             }
         }
+
+        // Custom cursor animator
+        binding.editor.cursorAnimator = FadeCursorAnimator(binding.editor)
 
         val editor = binding.editor
         var editorColorScheme = editor.colorScheme

--- a/editor/src/main/AndroidManifest.xml
+++ b/editor/src/main/AndroidManifest.xml
@@ -22,7 +22,8 @@
   ~     additional information or have any questions
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 
-<manifest>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <uses-permission android:name="android.permission.VIBRATE" />
 
 </manifest>

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/CodeEditor.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/CodeEditor.java
@@ -494,7 +494,7 @@ public class CodeEditor extends View implements ContentListener, StyleReceiver, 
         mMatrix = new Matrix();
         mHandleStyle = new HandleStyleSideDrop(getContext());
         mSearcher = new EditorSearcher(this);
-        mCursorAnimator = new CursorAnimator(this);
+        mCursorAnimator = new MoveCursorAnimator(this);
         setCursorBlinkPeriod(DEFAULT_CURSOR_BLINK_PERIOD);
         mAnchorInfoBuilder = new CursorAnchorInfo.Builder();
 
@@ -882,6 +882,10 @@ public class CodeEditor extends View implements ContentListener, StyleReceiver, 
             mCursorAnimator.cancel();
         }
         mCursorAnimation = enabled;
+    }
+
+    public void setCursorAnimator(CursorAnimator cursorAnimator) {
+        mCursorAnimator = cursorAnimator;
     }
 
     public CursorAnimator getCursorAnimator() {
@@ -2697,7 +2701,8 @@ public class CodeEditor extends View implements ContentListener, StyleReceiver, 
         updateCursor();
         mPainter.invalidateInCursor();
         if (!mEventHandler.hasAnyHeldHandle()) {
-            mCursorAnimator.markEndPosAndStart();
+            mCursorAnimator.markEndPos();
+            mCursorAnimator.start();
         }
         if (makeItVisible) {
             ensurePositionVisible(line, column);
@@ -3845,7 +3850,8 @@ public class CodeEditor extends View implements ContentListener, StyleReceiver, 
         mEventHandler.hideInsertHandle();
         onSelectionChanged(SelectionChangeEvent.CAUSE_TEXT_MODIFICATION);
         if (!mCursor.isSelected()) {
-            mCursorAnimator.markEndPosAndStart();
+            mCursorAnimator.markEndPos();
+            mCursorAnimator.start();
         }
         dispatchEvent(new ContentChangeEvent(this, ContentChangeEvent.ACTION_INSERT, start, end, insertedContent));
     }
@@ -3899,7 +3905,8 @@ public class CodeEditor extends View implements ContentListener, StyleReceiver, 
             mEventHandler.hideInsertHandle();
         }
         if (!mCursor.isSelected()) {
-            mCursorAnimator.markEndPosAndStart();
+            mCursorAnimator.markEndPos();
+            mCursorAnimator.start();
         }
         mLanguage.getAnalyzeManager().delete(start, end, deletedContent);
         onSelectionChanged(SelectionChangeEvent.CAUSE_TEXT_MODIFICATION);

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/CursorAnimator.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/CursorAnimator.java
@@ -23,92 +23,19 @@
  */
 package io.github.rosemoe.sora.widget;
 
-import android.animation.ValueAnimator;
+public interface CursorAnimator {
 
-/**
- * Helper class for cursor animation in editor
- *
- * @author Rosemoe
- */
-class CursorAnimator implements ValueAnimator.AnimatorUpdateListener {
+    void markStartPos();
+    void markEndPos();
 
-    ValueAnimator animatorX;
-    ValueAnimator animatorY;
-    ValueAnimator animatorBgBottom;
-    ValueAnimator animatorBackground;
-    private final CodeEditor editor;
-    private float startX, startY, startSize, startBottom;
-    private long lastAnimateTime;
+    void start();
+    void cancel();
 
-    public CursorAnimator(CodeEditor editor) {
-        this.editor = editor;
-        animatorX = new ValueAnimator();
-        animatorY = new ValueAnimator();
-        animatorBackground = new ValueAnimator();
-        animatorBgBottom = new ValueAnimator();
-    }
+    boolean isRunning();
 
-    public void markStartPos() {
-        var line = editor.getCursor().getLeftLine();
-        float[] pos = editor.mLayout.getCharLayoutOffset(line, editor.getCursor().getLeftColumn());
-        startX = editor.measureTextRegionOffset() + pos[1];
-        startY = pos[0];
-        startSize = editor.mLayout.getRowCountForLine(line) * editor.getRowHeight();
-        startBottom = editor.mLayout.getCharLayoutOffset(line, editor.getText().getColumnCount(line))[0];
-    }
+    float animatedX();
+    float animatedY();
 
-    public boolean isRunning() {
-        return animatorX.isRunning() || animatorY.isRunning() || animatorBackground.isRunning() || animatorBgBottom.isRunning();
-    }
-
-    public void cancel() {
-        animatorX.cancel();
-        animatorY.cancel();
-        animatorBackground.cancel();
-        animatorBgBottom.cancel();
-    }
-
-    public void markEndPosAndStart() {
-        if (!editor.isCursorAnimationEnabled()) {
-            return;
-        }
-        if (isRunning()) {
-            startX = (float) animatorX.getAnimatedValue();
-            startY = (float) animatorY.getAnimatedValue();
-            startSize = (float) animatorBackground.getAnimatedValue();
-            startBottom = (float) animatorBgBottom.getAnimatedValue();
-            cancel();
-        }
-        var duration = 120;
-        if (System.currentTimeMillis() - lastAnimateTime < 100) {
-            return;
-        }
-        var line = editor.getCursor().getLeftLine();
-        animatorX.removeAllUpdateListeners();
-        float[] pos = editor.mLayout.getCharLayoutOffset(editor.getCursor().getLeftLine(), editor.getCursor().getLeftColumn());
-
-        animatorX = ValueAnimator.ofFloat(startX, (pos[1] + editor.measureTextRegionOffset()));
-        animatorY = ValueAnimator.ofFloat(startY, pos[0]);
-        animatorBackground = ValueAnimator.ofFloat(startSize, editor.mLayout.getRowCountForLine(editor.getCursor().getLeftLine()) * editor.getRowHeight());
-        animatorBgBottom = ValueAnimator.ofFloat(startBottom, editor.mLayout.getCharLayoutOffset(line, editor.getText().getColumnCount(line))[0]);
-
-        animatorX.addUpdateListener(this);
-
-        animatorX.setDuration(duration);
-        animatorY.setDuration(duration);
-        animatorBackground.setDuration(duration);
-        animatorBgBottom.setDuration(duration);
-
-        animatorX.start();
-        animatorY.start();
-        animatorBackground.start();
-        animatorBgBottom.start();
-
-        lastAnimateTime = System.currentTimeMillis();
-    }
-
-    @Override
-    public void onAnimationUpdate(ValueAnimator animation) {
-        editor.postInvalidateOnAnimation();
-    }
+    float animatedLineHeight();
+    float animatedLineBottom();
 }

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/EditorPainter.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/EditorPainter.java
@@ -500,8 +500,8 @@ public class EditorPainter {
             int lineNumberColor = mEditor.getColorScheme().getColor(EditorColorScheme.LINE_NUMBER);
             int currentLineBgColor = mEditor.getColorScheme().getColor(EditorColorScheme.CURRENT_LINE);
             if (mEditor.getCursorAnimator().isRunning()) {
-                mRect.bottom = (float) mEditor.getCursorAnimator().animatorBgBottom.getAnimatedValue() - mEditor.getOffsetY();
-                mRect.top = mRect.bottom - (float) mEditor.getCursorAnimator().animatorBackground.getAnimatedValue();
+                mRect.bottom = mEditor.getCursorAnimator().animatedLineBottom() - mEditor.getOffsetY();
+                mRect.top = mRect.bottom - mEditor.getCursorAnimator().animatedLineHeight();
                 mRect.left = 0;
                 mRect.right = (int) (textOffset - mEditor.getDividerMargin());
                 drawColor(canvas, currentLineBgColor, mRect);
@@ -560,8 +560,8 @@ public class EditorPainter {
             int lineNumberColor = mEditor.getColorScheme().getColor(EditorColorScheme.LINE_NUMBER);
             int currentLineBgColor = mEditor.getColorScheme().getColor(EditorColorScheme.CURRENT_LINE);
             if (mEditor.getCursorAnimator().isRunning()) {
-                mRect.bottom = (float) mEditor.getCursorAnimator().animatorBgBottom.getAnimatedValue() - mEditor.getOffsetY();
-                mRect.top = mRect.bottom - (float) mEditor.getCursorAnimator().animatorBackground.getAnimatedValue();
+                mRect.bottom = mEditor.getCursorAnimator().animatedLineBottom() - mEditor.getOffsetY();
+                mRect.top = mRect.bottom - mEditor.getCursorAnimator().animatedLineHeight();
                 mRect.left = 0;
                 mRect.right = (int) (textOffset - mEditor.getDividerMargin());
                 drawColor(canvas, currentLineBgColor, mRect);
@@ -813,8 +813,8 @@ public class EditorPainter {
 
         // Draw current line background on animation
         if (mEditor.getCursorAnimator().isRunning()) {
-            mRect.bottom = (float) mEditor.getCursorAnimator().animatorBgBottom.getAnimatedValue() - mEditor.getOffsetY();
-            mRect.top = mRect.bottom - (float) mEditor.getCursorAnimator().animatorBackground.getAnimatedValue();
+            mRect.bottom = mEditor.getCursorAnimator().animatedLineBottom() - mEditor.getOffsetY();
+            mRect.top = mRect.bottom - mEditor.getCursorAnimator().animatedLineHeight();
             mRect.left = 0;
             mRect.right = mViewRect.right;
             drawColor(canvas, currentLineBgColor, mRect);
@@ -1638,9 +1638,9 @@ public class EditorPainter {
     }
 
     protected void drawSelectionOnAnimation(Canvas canvas) {
-        mRect.bottom = (float) mEditor.getCursorAnimator().animatorY.getAnimatedValue() - mEditor.getOffsetY();
+        mRect.bottom = mEditor.getCursorAnimator().animatedY() - mEditor.getOffsetY();
         mRect.top = mRect.bottom - mEditor.getRowHeight();
-        float centerX = (float) mEditor.getCursorAnimator().animatorX.getAnimatedValue() - mEditor.getOffsetX();
+        float centerX = mEditor.getCursorAnimator().animatedX() - mEditor.getOffsetX();
         mRect.left = centerX - mEditor.getInsertSelectionWidth() / 2;
         mRect.right = centerX + mEditor.getInsertSelectionWidth() / 2;
         drawColor(canvas, mEditor.getColorScheme().getColor(EditorColorScheme.SELECTION_INSERT), mRect);

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/EditorTouchEventHandler.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/EditorTouchEventHandler.java
@@ -23,8 +23,12 @@
  */
 package io.github.rosemoe.sora.widget;
 
+import android.annotation.SuppressLint;
+import android.content.Context;
 import android.content.res.Resources;
 import android.graphics.RectF;
+import android.os.Vibrator;
+import android.os.VibratorManager;
 import android.util.TypedValue;
 import android.view.GestureDetector;
 import android.view.MotionEvent;
@@ -53,6 +57,8 @@ public final class EditorTouchEventHandler implements GestureDetector.OnGestureL
 
     private final static int HIDE_DELAY = 3000;
     private final static int HIDE_DELAY_HANDLE = 5000;
+    private final static int VIBRATION_MILLIS = 30;
+
     private final CodeEditor mEditor;
     private final OverScroller mScroller;
     boolean topOrBottom; //true for bottom
@@ -70,6 +76,7 @@ public final class EditorTouchEventHandler implements GestureDetector.OnGestureL
     int mSelHandleType = -1;
     private int mTouchedHandleType = -1;
     Magnifier mMagnifier;
+    Vibrator mVibrator;
 
     private final static int LEFT_EDGE = 1;
     private final static int RIGHT_EDGE = 1 << 1;
@@ -91,6 +98,7 @@ public final class EditorTouchEventHandler implements GestureDetector.OnGestureL
         maxSize = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_SP, 26, Resources.getSystem().getDisplayMetrics());
         minSize = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_SP, 8, Resources.getSystem().getDisplayMetrics());
         mMagnifier = new Magnifier(editor);
+        mVibrator = (Vibrator) editor.getContext().getSystemService(Context.VIBRATOR_SERVICE);
     }
 
     public boolean hasAnyHeldHandle() {
@@ -507,6 +515,7 @@ public final class EditorTouchEventHandler implements GestureDetector.OnGestureL
         mEditor.setSelectionRegion(startLine, startColumn, endLine, endColumn, SelectionChangeEvent.CAUSE_LONG_PRESS);
     }
 
+    @SuppressLint("MissingPermission")
     @Override
     public void onLongPress(MotionEvent e) {
         long res = mEditor.getPointPositionOnScreen(e.getX(), e.getY());
@@ -518,6 +527,7 @@ public final class EditorTouchEventHandler implements GestureDetector.OnGestureL
         if (mEditor.getCursor().isSelected() || e.getPointerCount() != 1) {
             return;
         }
+        mVibrator.vibrate(VIBRATION_MILLIS);
         selectWord(line, column);
     }
 

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/FadeCursorAnimator.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/FadeCursorAnimator.java
@@ -1,0 +1,167 @@
+/*
+ *    sora-editor - the awesome code editor for Android
+ *    https://github.com/Rosemoe/sora-editor
+ *    Copyright (C) 2020-2022  Rosemoe
+ *
+ *     This library is free software; you can redistribute it and/or
+ *     modify it under the terms of the GNU Lesser General Public
+ *     License as published by the Free Software Foundation; either
+ *     version 2.1 of the License, or (at your option) any later version.
+ *
+ *     This library is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *     Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public
+ *     License along with this library; if not, write to the Free Software
+ *     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *     USA
+ *
+ *     Please contact Rosemoe by email 2073412493@qq.com if you need
+ *     additional information or have any questions
+ */
+package io.github.rosemoe.sora.widget;
+
+import android.animation.Animator;
+import android.animation.ValueAnimator;
+
+/**
+ * Fade-in/Fade-out cursor animation
+ *
+ * @author Dmitry Rubtsov
+ */
+public class FadeCursorAnimator implements CursorAnimator, ValueAnimator.AnimatorUpdateListener {
+
+    private final CodeEditor editor;
+    private final long duration;
+
+    private ValueAnimator fadeInAnimator;
+    private ValueAnimator fadeOutAnimator;
+
+    private boolean phaseEnded;
+    private long lastAnimateTime;
+    private float lineHeight, lineBottom;
+    private float startX, startY, endX, endY;
+
+    public FadeCursorAnimator(CodeEditor editor) {
+        this.editor = editor;
+        this.fadeInAnimator = new ValueAnimator();
+        this.fadeOutAnimator = new ValueAnimator();
+        this.duration = 100;
+    }
+
+    @Override
+    public void markStartPos() {
+        int line = editor.getCursor().getLeftLine();
+        lineHeight = editor.mLayout.getRowCountForLine(line) * editor.getRowHeight();
+        lineBottom = editor.mLayout.getCharLayoutOffset(line, editor.getText().getColumnCount(line))[0];
+
+        float[] pos = editor.mLayout.getCharLayoutOffset(
+                editor.getCursor().getLeftLine(),
+                editor.getCursor().getLeftColumn()
+        );
+        startX = pos[1] + editor.measureTextRegionOffset();
+        startY = pos[0];
+    }
+
+    @Override
+    public boolean isRunning() {
+        return fadeInAnimator.isRunning() || fadeOutAnimator.isRunning();
+    }
+
+    @Override
+    public void cancel() {
+        fadeOutAnimator.cancel();
+        fadeInAnimator.cancel();
+    }
+
+    @Override
+    public void markEndPos() {
+        if (!editor.isCursorAnimationEnabled()) {
+            return;
+        }
+        if (isRunning()) {
+            cancel();
+        }
+        if (System.currentTimeMillis() - lastAnimateTime < 100) {
+            return;
+        }
+        fadeOutAnimator.removeAllUpdateListeners();
+        fadeInAnimator.removeAllUpdateListeners();
+
+        int line = editor.getCursor().getLeftLine();
+        lineHeight = editor.mLayout.getRowCountForLine(line) * editor.getRowHeight();
+        lineBottom = editor.mLayout.getCharLayoutOffset(line, editor.getText().getColumnCount(line))[0];
+
+        float[] pos = editor.mLayout.getCharLayoutOffset(
+                editor.getCursor().getLeftLine(),
+                editor.getCursor().getLeftColumn()
+        );
+        endX = pos[1] + editor.measureTextRegionOffset();
+        endY = pos[0];
+
+        fadeOutAnimator = ValueAnimator.ofInt(255, 0);
+        fadeOutAnimator.addListener(new Animator.AnimatorListener() {
+            @Override
+            public void onAnimationCancel(Animator animator) {}
+            @Override
+            public void onAnimationRepeat(Animator animator) {}
+            @Override
+            public void onAnimationStart(Animator animator) {
+                phaseEnded = false;
+            }
+            @Override
+            public void onAnimationEnd(Animator animator) {
+                phaseEnded = true;
+            }
+        });
+        fadeOutAnimator.addUpdateListener(this);
+        fadeOutAnimator.setDuration(duration);
+
+        fadeInAnimator = ValueAnimator.ofInt(0, 255);
+        fadeInAnimator.addUpdateListener(this);
+        fadeInAnimator.setStartDelay(duration);
+        fadeInAnimator.setDuration(duration);
+    }
+
+    @Override
+    public void start() {
+        fadeOutAnimator.start();
+        fadeInAnimator.start();
+        lastAnimateTime = System.currentTimeMillis();
+    }
+
+    @Override
+    public float animatedX() {
+        if (phaseEnded) {
+            return endX;
+        }
+        return startX;
+    }
+
+    @Override
+    public float animatedY() {
+        if (phaseEnded) {
+            return endY;
+        }
+        return startY;
+    }
+
+    @Override
+    public float animatedLineHeight() {
+        return lineHeight;
+    }
+
+    @Override
+    public float animatedLineBottom() {
+        return lineBottom;
+    }
+
+    @Override
+    public void onAnimationUpdate(ValueAnimator animation) {
+        editor.getHandleStyle().setAlpha((int) animation.getAnimatedValue());
+        editor.getEditorPainter().invalidateInCursor();
+        editor.postInvalidateOnAnimation();
+    }
+}

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/MoveCursorAnimator.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/MoveCursorAnimator.java
@@ -1,0 +1,143 @@
+/*
+ *    sora-editor - the awesome code editor for Android
+ *    https://github.com/Rosemoe/sora-editor
+ *    Copyright (C) 2020-2022  Rosemoe
+ *
+ *     This library is free software; you can redistribute it and/or
+ *     modify it under the terms of the GNU Lesser General Public
+ *     License as published by the Free Software Foundation; either
+ *     version 2.1 of the License, or (at your option) any later version.
+ *
+ *     This library is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *     Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public
+ *     License along with this library; if not, write to the Free Software
+ *     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *     USA
+ *
+ *     Please contact Rosemoe by email 2073412493@qq.com if you need
+ *     additional information or have any questions
+ */
+package io.github.rosemoe.sora.widget;
+
+import android.animation.ValueAnimator;
+
+/**
+ * Helper class for cursor animation in editor
+ *
+ * @author Rosemoe
+ */
+class MoveCursorAnimator implements CursorAnimator, ValueAnimator.AnimatorUpdateListener {
+
+    private ValueAnimator animatorX;
+    private ValueAnimator animatorY;
+    private ValueAnimator animatorBgBottom;
+    private ValueAnimator animatorBackground;
+
+    private final CodeEditor editor;
+    private float startX, startY, startSize, startBottom;
+    private long lastAnimateTime;
+
+    public MoveCursorAnimator(CodeEditor editor) {
+        this.editor = editor;
+        animatorX = new ValueAnimator();
+        animatorY = new ValueAnimator();
+        animatorBackground = new ValueAnimator();
+        animatorBgBottom = new ValueAnimator();
+    }
+
+    @Override
+    public void markStartPos() {
+        var line = editor.getCursor().getLeftLine();
+        float[] pos = editor.mLayout.getCharLayoutOffset(line, editor.getCursor().getLeftColumn());
+        startX = editor.measureTextRegionOffset() + pos[1];
+        startY = pos[0];
+        startSize = editor.mLayout.getRowCountForLine(line) * editor.getRowHeight();
+        startBottom = editor.mLayout.getCharLayoutOffset(line, editor.getText().getColumnCount(line))[0];
+    }
+
+    @Override
+    public boolean isRunning() {
+        return animatorX.isRunning() || animatorY.isRunning() || animatorBackground.isRunning() || animatorBgBottom.isRunning();
+    }
+
+    @Override
+    public void cancel() {
+        animatorX.cancel();
+        animatorY.cancel();
+        animatorBackground.cancel();
+        animatorBgBottom.cancel();
+    }
+
+    @Override
+    public void markEndPos() {
+        if (!editor.isCursorAnimationEnabled()) {
+            return;
+        }
+        if (isRunning()) {
+            startX = animatedX();
+            startY = animatedY();
+            startSize = (float) animatorBackground.getAnimatedValue();
+            startBottom = (float) animatorBgBottom.getAnimatedValue();
+            cancel();
+        }
+        var duration = 120;
+        if (System.currentTimeMillis() - lastAnimateTime < 100) {
+            return;
+        }
+        var line = editor.getCursor().getLeftLine();
+        animatorX.removeAllUpdateListeners();
+        float[] pos = editor.mLayout.getCharLayoutOffset(editor.getCursor().getLeftLine(), editor.getCursor().getLeftColumn());
+
+        animatorX = ValueAnimator.ofFloat(startX, (pos[1] + editor.measureTextRegionOffset()));
+        animatorY = ValueAnimator.ofFloat(startY, pos[0]);
+
+        animatorBackground = ValueAnimator.ofFloat(startSize, editor.mLayout.getRowCountForLine(editor.getCursor().getLeftLine()) * editor.getRowHeight());
+        animatorBgBottom = ValueAnimator.ofFloat(startBottom, editor.mLayout.getCharLayoutOffset(line, editor.getText().getColumnCount(line))[0]);
+
+        animatorX.addUpdateListener(this);
+
+        animatorX.setDuration(duration);
+        animatorY.setDuration(duration);
+        animatorBackground.setDuration(duration);
+        animatorBgBottom.setDuration(duration);
+    }
+
+    @Override
+    public void start() {
+        animatorX.start();
+        animatorY.start();
+        animatorBackground.start();
+        animatorBgBottom.start();
+
+        lastAnimateTime = System.currentTimeMillis();
+    }
+
+    @Override
+    public float animatedX() {
+        return (float) animatorX.getAnimatedValue();
+    }
+
+    @Override
+    public float animatedY() {
+        return (float) animatorY.getAnimatedValue();
+    }
+
+    @Override
+    public float animatedLineHeight() {
+        return (float) animatorBackground.getAnimatedValue();
+    }
+
+    @Override
+    public float animatedLineBottom() {
+        return (float) animatorBgBottom.getAnimatedValue();
+    }
+
+    @Override
+    public void onAnimationUpdate(ValueAnimator animation) {
+        editor.postInvalidateOnAnimation();
+    }
+}

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/MoveCursorAnimator.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/MoveCursorAnimator.java
@@ -26,11 +26,11 @@ package io.github.rosemoe.sora.widget;
 import android.animation.ValueAnimator;
 
 /**
- * Helper class for cursor animation in editor
+ * Default cursor animation implementation
  *
  * @author Rosemoe
  */
-class MoveCursorAnimator implements CursorAnimator, ValueAnimator.AnimatorUpdateListener {
+public class MoveCursorAnimator implements CursorAnimator, ValueAnimator.AnimatorUpdateListener {
 
     private ValueAnimator animatorX;
     private ValueAnimator animatorY;
@@ -39,6 +39,8 @@ class MoveCursorAnimator implements CursorAnimator, ValueAnimator.AnimatorUpdate
 
     private final CodeEditor editor;
     private float startX, startY, startSize, startBottom;
+
+    private final long duration;
     private long lastAnimateTime;
 
     public MoveCursorAnimator(CodeEditor editor) {
@@ -47,6 +49,7 @@ class MoveCursorAnimator implements CursorAnimator, ValueAnimator.AnimatorUpdate
         animatorY = new ValueAnimator();
         animatorBackground = new ValueAnimator();
         animatorBgBottom = new ValueAnimator();
+        duration = 120;
     }
 
     @Override
@@ -84,7 +87,6 @@ class MoveCursorAnimator implements CursorAnimator, ValueAnimator.AnimatorUpdate
             startBottom = (float) animatorBgBottom.getAnimatedValue();
             cancel();
         }
-        var duration = 120;
         if (System.currentTimeMillis() - lastAnimateTime < 100) {
             return;
         }

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/ScaleCursorAnimator.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/ScaleCursorAnimator.java
@@ -1,0 +1,167 @@
+/*
+ *    sora-editor - the awesome code editor for Android
+ *    https://github.com/Rosemoe/sora-editor
+ *    Copyright (C) 2020-2022  Rosemoe
+ *
+ *     This library is free software; you can redistribute it and/or
+ *     modify it under the terms of the GNU Lesser General Public
+ *     License as published by the Free Software Foundation; either
+ *     version 2.1 of the License, or (at your option) any later version.
+ *
+ *     This library is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *     Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public
+ *     License along with this library; if not, write to the Free Software
+ *     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *     USA
+ *
+ *     Please contact Rosemoe by email 2073412493@qq.com if you need
+ *     additional information or have any questions
+ */
+package io.github.rosemoe.sora.widget;
+
+import android.animation.Animator;
+import android.animation.ValueAnimator;
+
+/**
+ * Scale-Up/Scale-Down cursor animation
+ *
+ * @author Dmitry Rubtsov
+ */
+public class ScaleCursorAnimator implements CursorAnimator, ValueAnimator.AnimatorUpdateListener {
+
+    private final CodeEditor editor;
+    private final long duration;
+
+    private ValueAnimator scaleUpAnimator;
+    private ValueAnimator scaleDownAnimator;
+
+    private boolean phaseEnded;
+    private long lastAnimateTime;
+    private float lineHeight, lineBottom;
+    private float startX, startY, endX, endY;
+
+    public ScaleCursorAnimator(CodeEditor editor) {
+        this.editor = editor;
+        this.scaleUpAnimator = new ValueAnimator();
+        this.scaleDownAnimator = new ValueAnimator();
+        this.duration = 100;
+    }
+
+    @Override
+    public void markStartPos() {
+        int line = editor.getCursor().getLeftLine();
+        lineHeight = editor.mLayout.getRowCountForLine(line) * editor.getRowHeight();
+        lineBottom = editor.mLayout.getCharLayoutOffset(line, editor.getText().getColumnCount(line))[0];
+
+        float[] pos = editor.mLayout.getCharLayoutOffset(
+                editor.getCursor().getLeftLine(),
+                editor.getCursor().getLeftColumn()
+        );
+        startX = pos[1] + editor.measureTextRegionOffset();
+        startY = pos[0];
+    }
+
+    @Override
+    public boolean isRunning() {
+        return scaleUpAnimator.isRunning() || scaleDownAnimator.isRunning();
+    }
+
+    @Override
+    public void cancel() {
+        scaleDownAnimator.cancel();
+        scaleUpAnimator.cancel();
+    }
+
+    @Override
+    public void markEndPos() {
+        if (!editor.isCursorAnimationEnabled()) {
+            return;
+        }
+        if (isRunning()) {
+            cancel();
+        }
+        if (System.currentTimeMillis() - lastAnimateTime < 100) {
+            return;
+        }
+        scaleDownAnimator.removeAllUpdateListeners();
+        scaleUpAnimator.removeAllUpdateListeners();
+
+        int line = editor.getCursor().getLeftLine();
+        lineHeight = editor.mLayout.getRowCountForLine(line) * editor.getRowHeight();
+        lineBottom = editor.mLayout.getCharLayoutOffset(line, editor.getText().getColumnCount(line))[0];
+
+        float[] pos = editor.mLayout.getCharLayoutOffset(
+                editor.getCursor().getLeftLine(),
+                editor.getCursor().getLeftColumn()
+        );
+        endX = pos[1] + editor.measureTextRegionOffset();
+        endY = pos[0];
+
+        scaleDownAnimator = ValueAnimator.ofFloat(1.0f, 0f);
+        scaleDownAnimator.addListener(new Animator.AnimatorListener() {
+            @Override
+            public void onAnimationCancel(Animator animator) {}
+            @Override
+            public void onAnimationRepeat(Animator animator) {}
+            @Override
+            public void onAnimationStart(Animator animator) {
+                phaseEnded = false;
+            }
+            @Override
+            public void onAnimationEnd(Animator animator) {
+                phaseEnded = true;
+            }
+        });
+        scaleDownAnimator.addUpdateListener(this);
+        scaleDownAnimator.setDuration(duration);
+
+        scaleUpAnimator = ValueAnimator.ofFloat(0f, 1.0f);
+        scaleUpAnimator.addUpdateListener(this);
+        scaleUpAnimator.setStartDelay(duration);
+        scaleUpAnimator.setDuration(duration);
+    }
+
+    @Override
+    public void start() {
+        scaleDownAnimator.start();
+        scaleUpAnimator.start();
+        lastAnimateTime = System.currentTimeMillis();
+    }
+
+    @Override
+    public float animatedX() {
+        if (phaseEnded) {
+            return endX;
+        }
+        return startX;
+    }
+
+    @Override
+    public float animatedY() {
+        if (phaseEnded) {
+            return endY;
+        }
+        return startY;
+    }
+
+    @Override
+    public float animatedLineHeight() {
+        return lineHeight;
+    }
+
+    @Override
+    public float animatedLineBottom() {
+        return lineBottom;
+    }
+
+    @Override
+    public void onAnimationUpdate(ValueAnimator animation) {
+        editor.getHandleStyle().setScale((float) animation.getAnimatedValue());
+        editor.getEditorPainter().invalidateInCursor();
+        editor.postInvalidateOnAnimation();
+    }
+}

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/style/SelectionHandleStyle.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/style/SelectionHandleStyle.java
@@ -58,6 +58,8 @@ public interface SelectionHandleStyle {
      */
     void draw(@NonNull Canvas canvas, int handleType, float x, float y, int rowHeight, int color, @NonNull HandleDescriptor descriptor);
 
+    void setAlpha(int alpha);
+
     /**
      * The descriptor of a drawn handle on canvas
      */

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/style/SelectionHandleStyle.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/style/SelectionHandleStyle.java
@@ -60,6 +60,8 @@ public interface SelectionHandleStyle {
 
     void setAlpha(int alpha);
 
+    void setScale(float factor);
+
     /**
      * The descriptor of a drawn handle on canvas
      */

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/style/builtin/HandleStyleDrop.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/style/builtin/HandleStyleDrop.java
@@ -41,6 +41,7 @@ public class HandleStyleDrop implements SelectionHandleStyle {
     private final int width;
     private final int height;
     private int lastColor = 0;
+    private int alpha = 255;
 
     public HandleStyleDrop(Context context) {
         drawable = context.getDrawable(R.drawable.ic_sora_handle_drop).mutate();
@@ -54,10 +55,16 @@ public class HandleStyleDrop implements SelectionHandleStyle {
             lastColor = color;
             drawable.setColorFilter(new PorterDuffColorFilter(color, PorterDuff.Mode.SRC_ATOP));
         }
-        var cx = (int)x;
-        var ty = (int)y;
+        var cx = (int) x;
+        var ty = (int) y;
         drawable.setBounds(cx - width / 2, ty, cx + width / 2, ty + height);
+        drawable.setAlpha(alpha);
         drawable.draw(canvas);
-        descriptor.set(cx - width / 2, ty, cx + width / 2, ty + height, ALIGN_CENTER);
+        descriptor.set(cx - width / 2f, ty, cx + width / 2f, ty + height, ALIGN_CENTER);
+    }
+
+    @Override
+    public void setAlpha(int alpha) {
+        this.alpha = alpha;
     }
 }

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/style/builtin/HandleStyleDrop.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/style/builtin/HandleStyleDrop.java
@@ -41,7 +41,9 @@ public class HandleStyleDrop implements SelectionHandleStyle {
     private final int width;
     private final int height;
     private int lastColor = 0;
+
     private int alpha = 255;
+    private float scaleFactor = 1.0f;
 
     public HandleStyleDrop(Context context) {
         drawable = context.getDrawable(R.drawable.ic_sora_handle_drop).mutate();
@@ -55,16 +57,23 @@ public class HandleStyleDrop implements SelectionHandleStyle {
             lastColor = color;
             drawable.setColorFilter(new PorterDuffColorFilter(color, PorterDuff.Mode.SRC_ATOP));
         }
-        var cx = (int) x;
-        var ty = (int) y;
-        drawable.setBounds(cx - width / 2, ty, cx + width / 2, ty + height);
+        var left = (int) (x - (width * scaleFactor) / 2);
+        var top = (int) y;
+        var right = (int) (x + (width * scaleFactor) / 2);
+        var bottom = (int) (y + height * scaleFactor);
+        drawable.setBounds(left, top, right, bottom);
         drawable.setAlpha(alpha);
         drawable.draw(canvas);
-        descriptor.set(cx - width / 2f, ty, cx + width / 2f, ty + height, ALIGN_CENTER);
+        descriptor.set(left, top, right, bottom, ALIGN_CENTER);
     }
 
     @Override
     public void setAlpha(int alpha) {
         this.alpha = alpha;
+    }
+
+    @Override
+    public void setScale(float factor) {
+        this.scaleFactor = factor;
     }
 }

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/style/builtin/HandleStyleSideDrop.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/style/builtin/HandleStyleSideDrop.java
@@ -44,7 +44,7 @@ public class HandleStyleSideDrop extends HandleStyleDrop {
     
     @Override
     public void draw(@NonNull Canvas canvas, int handleType, float x, float y, int rowHeight, int color, @NonNull HandleDescriptor descriptor) {
-        float radius = size / 2;
+        float radius = size / 2f;
         paint.setColor(color);
         if (handleType == HANDLE_TYPE_INSERT || handleType == HANDLE_TYPE_UNDEFINED) {
             super.draw(canvas, handleType, x, y, rowHeight, color, descriptor);
@@ -56,5 +56,4 @@ public class HandleStyleSideDrop extends HandleStyleDrop {
             descriptor.set(cx - radius, y, cx + radius, y + 2 * radius, type ? ALIGN_LEFT : ALIGN_RIGHT);
         }
     }
-    
 }


### PR DESCRIPTION
I'm not sure if it's okay to put `setScale()` and `setAlpha()` methods in `SelectionHandleStyle`, but you got the idea
\+ Vibrate on long press just like normal EditText widget

_FadeCursorAnimator_
![fade](https://user-images.githubusercontent.com/7825871/166245635-d5034c47-980e-47aa-9fe7-3e6f3b56b042.gif)

_ScaleCursorAnimator_
![scale](https://user-images.githubusercontent.com/7825871/166245658-d87e9a1a-332e-4cc1-9445-5ed4c82dea0c.gif)