### PR TITLE
Support for sticky text selection

### DIFF
--- a/editor/src/main/java/io/github/rosemoe/sora/widget/CodeEditor.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/CodeEditor.java
@@ -267,6 +267,7 @@ public class CodeEditor extends View implements ContentListener, StyleReceiver, 
     private boolean mFirstLineNumberAlwaysVisible;
     private boolean mLigatureEnabled;
     private boolean mLastCursorState;
+    private boolean mStickyTextSelection;
     private SelectionHandleStyle.HandleDescriptor mLeftHandle;
     private SelectionHandleStyle.HandleDescriptor mRightHandle;
     private SelectionHandleStyle.HandleDescriptor mInsertHandle;
@@ -759,6 +760,22 @@ public class CodeEditor extends View implements ContentListener, StyleReceiver, 
             mCursorPosition = findCursorBlock();
         }
         invalidate();
+    }
+
+    /**
+     * Returns whether the cursor should stick to the text row while selecting the text
+     * @see CodeEditor#setStickyTextSelection(boolean)
+     */
+    public boolean isStickyTextSelection() {
+        return mStickyTextSelection;
+    }
+
+    /**
+     * Whether the cursor should stick to the text row while selecting the text.
+     * @param stickySelection value
+     */
+    public void setStickyTextSelection(boolean stickySelection) {
+        this.mStickyTextSelection = stickySelection;
     }
 
     /**

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/EditorPainter.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/EditorPainter.java
@@ -1367,13 +1367,32 @@ public class EditorPainter {
             if (mEditor.mConnection.mImeConsumingInput) {
                 return;
             }
-            // Follow the thumb
+            // Follow the thumb or stick to text row
             if (!descriptor.position.isEmpty()) {
-                if ((mEditor.getEventHandler().holdInsertHandle() && handleType == SelectionHandleStyle.HANDLE_TYPE_INSERT)
-                        || (mEditor.getEventHandler().mSelHandleType == EditorTouchEventHandler.SelectionHandle.LEFT && handleType == SelectionHandleStyle.HANDLE_TYPE_LEFT)
-                        || (mEditor.getEventHandler().mSelHandleType == EditorTouchEventHandler.SelectionHandle.RIGHT && handleType == SelectionHandleStyle.HANDLE_TYPE_RIGHT)) {
-                    x = mEditor.getEventHandler().mMotionX + (descriptor.alignment != SelectionHandleStyle.ALIGN_CENTER ? descriptor.position.width() : 0) * (descriptor.alignment == SelectionHandleStyle.ALIGN_LEFT ? 1 : -1);
-                    y = mEditor.getEventHandler().mMotionY - descriptor.position.height() * 2 / 3f;
+                boolean isSingleHandle = mEditor.getEventHandler().holdInsertHandle() && handleType == SelectionHandleStyle.HANDLE_TYPE_INSERT;
+                boolean isLeftHandle = mEditor.getEventHandler().mSelHandleType == EditorTouchEventHandler.SelectionHandle.LEFT && handleType == SelectionHandleStyle.HANDLE_TYPE_LEFT;
+                boolean isRightHandle = mEditor.getEventHandler().mSelHandleType == EditorTouchEventHandler.SelectionHandle.RIGHT && handleType == SelectionHandleStyle.HANDLE_TYPE_RIGHT;
+                if (mEditor.isStickyTextSelection()) {
+                    if (isLeftHandle) {
+                        x = mCursor.getLeftColumn() * mEditor.getTextPaint().getSpaceWidth() +
+                                mEditor.measureTextRegionOffset() -
+                                mEditor.getOffsetX();
+                        y = mCursor.getLeftLine() * mEditor.getRowHeight() +
+                                mEditor.getRowHeight() -
+                                mEditor.getOffsetY();
+                    } else if (isRightHandle) {
+                        x = mCursor.getRightColumn() * mEditor.getTextPaint().getSpaceWidth() +
+                                mEditor.measureTextRegionOffset() -
+                                mEditor.getOffsetX();
+                        y = mCursor.getRightLine() * mEditor.getRowHeight() +
+                                mEditor.getRowHeight() -
+                                mEditor.getOffsetY();
+                    }
+                } else {
+                    if (isSingleHandle || isLeftHandle || isRightHandle) {
+                        x = mEditor.getEventHandler().mMotionX + (descriptor.alignment != SelectionHandleStyle.ALIGN_CENTER ? descriptor.position.width() : 0) * (descriptor.alignment == SelectionHandleStyle.ALIGN_LEFT ? 1 : -1);
+                        y = mEditor.getEventHandler().mMotionY - descriptor.position.height() * 2 / 3f;
+                    }
                 }
             }
 


### PR DESCRIPTION
Provide support for sticky text selection as if it would be a normal EditText

_isStickyTextSelection = true_
![sticky](https://user-images.githubusercontent.com/7825871/166301199-f1a32aae-effc-451a-b49f-f1a59e489fb6.gif)

_isStickyTextSelection = false_
![not_sticky](https://user-images.githubusercontent.com/7825871/166301237-ee1b1dc3-40b6-4a01-8951-6df322cbd455.gif)
