### PR TITLE
fix XXE vulnerability in XML Parsing

### DIFF
--- a/language-textmate/src/main/java/io/github/rosemoe/sora/textmate/core/internal/parser/xml/XMLPListParser.java
+++ b/language-textmate/src/main/java/io/github/rosemoe/sora/textmate/core/internal/parser/xml/XMLPListParser.java
@@ -19,6 +19,7 @@ import java.io.InputStream;
 
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
+import javax.xml.XMLConstants;
 
 import io.github.rosemoe.sora.textmate.core.internal.parser.PList;
 
@@ -33,6 +34,7 @@ public class XMLPListParser<T> {
     public T parse(InputStream contents) throws Exception {
         SAXParserFactory spf = SAXParserFactory.newInstance();
         spf.setNamespaceAware(true);
+        spf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
         SAXParser saxParser = spf.newSAXParser();
         XMLReader xmlReader = saxParser.getXMLReader();
         xmlReader.setEntityResolver((arg0, arg1) -> new InputSource(new ByteArrayInputStream("<?xml version='1.0' encoding='UTF-8'?>".getBytes())));


### PR DESCRIPTION
By the way, it would be better to use XmlPullParser and Driver instead of SAX as it is more efficient and is recommended in android docs