### PR TITLE
Improve magnifier

### DIFF
--- a/app/src/main/java/io/github/rosemoe/sora/app/MainActivity.kt
+++ b/app/src/main/java/io/github/rosemoe/sora/app/MainActivity.kt
@@ -121,9 +121,8 @@ class MainActivity : AppCompatActivity() {
 
         // Custom cursor animator
         binding.editor.cursorAnimator =
-            ScaleCursorAnimator(
-                binding.editor
-            )
+            ScaleCursorAnimator(binding.editor)
+        binding.editor.isStickyTextSelection = true
 
         val editor = binding.editor
         var editorColorScheme = editor.colorScheme

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/EditorPainter.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/EditorPainter.java
@@ -1377,7 +1377,7 @@ public class EditorPainter {
             }
             // Follow the thumb or stick to text row
             if (!descriptor.position.isEmpty()) {
-                boolean isSingleHandle = mEditor.getEventHandler().holdInsertHandle() && handleType == SelectionHandleStyle.HANDLE_TYPE_INSERT;
+                boolean isInsertHandle = mEditor.getEventHandler().holdInsertHandle() && handleType == SelectionHandleStyle.HANDLE_TYPE_INSERT;
                 boolean isLeftHandle = mEditor.getEventHandler().selHandleType == EditorTouchEventHandler.SelectionHandle.LEFT && handleType == SelectionHandleStyle.HANDLE_TYPE_LEFT;
                 boolean isRightHandle = mEditor.getEventHandler().selHandleType == EditorTouchEventHandler.SelectionHandle.RIGHT && handleType == SelectionHandleStyle.HANDLE_TYPE_RIGHT;
                 if (mEditor.isStickyTextSelection()) {
@@ -1397,7 +1397,7 @@ public class EditorPainter {
                                 mEditor.getOffsetY();
                     }
                 } else {
-                    if (isSingleHandle || isLeftHandle || isRightHandle) {
+                    if (isInsertHandle || isLeftHandle || isRightHandle) {
                         x = mEditor.getEventHandler().motionX + (descriptor.alignment != SelectionHandleStyle.ALIGN_CENTER ? descriptor.position.width() : 0) * (descriptor.alignment == SelectionHandleStyle.ALIGN_LEFT ? 1 : -1);
                         y = mEditor.getEventHandler().motionY - descriptor.position.height() * 2 / 3f;
                     }

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/EditorTouchEventHandler.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/EditorTouchEventHandler.java
@@ -238,16 +238,19 @@ public final class EditorTouchEventHandler implements GestureDetector.OnGestureL
                 boolean isLeftHandle = selHandleType == SelectionHandle.LEFT;
                 boolean isRightHandle = selHandleType == SelectionHandle.RIGHT;
 
-                float y = 0;
+                float x = 0, y = 0;
                 var height = Math.max(Math.max(insertHandlePos.height(), leftHandlePos.height()), rightHandlePos.height());
                 if (holdInsertHandle()) {
+                    x = Math.abs(insertHandlePos.left - e.getX()) > mEditor.getRowHeight() ? insertHandlePos.left : e.getX();
                     y = insertHandlePos.top;
                 } else if (isLeftHandle) {
+                    x = Math.abs(leftHandlePos.left - e.getX()) > mEditor.getRowHeight() ? leftHandlePos.left : e.getX();
                     y = leftHandlePos.top;
                 } else if (isRightHandle) {
+                    x = Math.abs(rightHandlePos.left - e.getX()) > mEditor.getRowHeight() ? rightHandlePos.left : e.getX();
                     y = rightHandlePos.top;
                 }
-                mMagnifier.show((int) e.getX(), (int) (y - height / 2));
+                mMagnifier.show((int) x, (int) (y - height / 2));
             } else {
                 var height = Math.max(Math.max(insertHandlePos.height(), leftHandlePos.height()), rightHandlePos.height());
                 mMagnifier.show((int) e.getX(), (int) (e.getY() - height / 2 - mEditor.getRowHeight()));
@@ -294,10 +297,10 @@ public final class EditorTouchEventHandler implements GestureDetector.OnGestureL
                 }
                 if (shouldDrawInsertHandle() && mEditor.getInsertHandleDescriptor().position.contains(e.getX(), e.getY())) {
                     mHoldingInsertHandle = true;
+                    dispatchHandle(HandleStateChangeEvent.HANDLE_TYPE_INSERT, true);
+                    updateMagnifier(e);
                     mThumbDownY = e.getY();
                     mThumbDownX = e.getX();
-                    updateMagnifier(e);
-                    dispatchHandle(HandleStateChangeEvent.HANDLE_TYPE_INSERT, true);
                 }
                 boolean left = mEditor.getLeftHandleDescriptor().position.contains(e.getX(), e.getY());
                 boolean right = mEditor.getRightHandleDescriptor().position.contains(e.getX(), e.getY());
@@ -310,9 +313,9 @@ public final class EditorTouchEventHandler implements GestureDetector.OnGestureL
                         mTouchedHandleType = SelectionHandle.RIGHT;
                     }
                     dispatchHandle(selHandleType, true);
+                    updateMagnifier(e);
                     mThumbDownY = e.getY();
                     mThumbDownX = e.getX();
-                    updateMagnifier(e);
                 }
                 return true;
             }

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/EditorTouchEventHandler.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/EditorTouchEventHandler.java
@@ -25,6 +25,7 @@ package io.github.rosemoe.sora.widget;
 
 import android.content.res.Resources;
 import android.graphics.RectF;
+import android.util.Log;
 import android.util.TypedValue;
 import android.view.HapticFeedbackConstants;
 import android.view.GestureDetector;
@@ -230,8 +231,27 @@ public final class EditorTouchEventHandler implements GestureDetector.OnGestureL
             return;
         }
         if (mMagnifier.isEnabled()) {
-            var height = Math.max(Math.max(mEditor.getInsertHandleDescriptor().position.height(), mEditor.getLeftHandleDescriptor().position.height()), mEditor.getRightHandleDescriptor().position.height());
-            mMagnifier.show((int) e.getX(), (int) (e.getY() - height / 2 - mEditor.getRowHeight()));
+            var insertHandlePos = mEditor.getInsertHandleDescriptor().position;
+            var leftHandlePos = mEditor.getLeftHandleDescriptor().position;
+            var rightHandlePos = mEditor.getRightHandleDescriptor().position;
+            if (mEditor.isStickyTextSelection()) {
+                boolean isLeftHandle = selHandleType == SelectionHandle.LEFT;
+                boolean isRightHandle = selHandleType == SelectionHandle.RIGHT;
+
+                float y = 0;
+                var height = Math.max(Math.max(insertHandlePos.height(), leftHandlePos.height()), rightHandlePos.height());
+                if (holdInsertHandle()) {
+                    y = insertHandlePos.top;
+                } else if (isLeftHandle) {
+                    y = leftHandlePos.top;
+                } else if (isRightHandle) {
+                    y = rightHandlePos.top;
+                }
+                mMagnifier.show((int) e.getX(), (int) (y - height / 2));
+            } else {
+                var height = Math.max(Math.max(insertHandlePos.height(), leftHandlePos.height()), rightHandlePos.height());
+                mMagnifier.show((int) e.getX(), (int) (e.getY() - height / 2 - mEditor.getRowHeight()));
+            }
         }
     }
 

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/component/Magnifier.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/component/Magnifier.java
@@ -77,8 +77,9 @@ public class Magnifier implements EditorBuiltinComponent {
         view = editor;
         parentView = editor;
         popup = new PopupWindow();
-        popup.setElevation(view.getDpUnit() * 8);
-        @SuppressLint("InflateParams") var view = LayoutInflater.from(editor.getContext()).inflate(R.layout.magnifier_popup, null);
+        popup.setElevation(view.getDpUnit() * 4);
+        @SuppressLint("InflateParams")
+        var view = LayoutInflater.from(editor.getContext()).inflate(R.layout.magnifier_popup, null);
         image = view.findViewById(R.id.magnifier_image_view);
         popup.setHeight((int) (editor.getDpUnit() * 70));
         popup.setWidth((int) (editor.getDpUnit() * 100));
@@ -181,7 +182,7 @@ public class Magnifier implements EditorBuiltinComponent {
             right = view.getWidth() + pos[0];
             left = Math.max(0, right - popup.getWidth());
         }
-        var top = Math.max(pos[1] + y - popup.getHeight() - (int) (view.getRowHeight()), 0);
+        var top = Math.max(pos[1] + y - popup.getHeight() - view.getRowHeight(), 0);
         if (popup.isShowing()) {
             popup.update(left, top, popup.getWidth(), popup.getHeight());
         } else {
@@ -261,7 +262,7 @@ public class Magnifier implements EditorBuiltinComponent {
                 }
                 if (statusCode == PixelCopy.SUCCESS) {
                     var dest = Bitmap.createBitmap(popup.getWidth(), popup.getHeight(), Bitmap.Config.ARGB_8888);
-                    var scaled = Bitmap.createScaledBitmap(clip, popup.getWidth(), popup.getHeight(), false);
+                    var scaled = Bitmap.createScaledBitmap(clip, popup.getWidth(), popup.getHeight(), true);
                     clip.recycle();
 
                     Canvas canvas = new Canvas(dest);
@@ -318,7 +319,7 @@ public class Magnifier implements EditorBuiltinComponent {
         var viewCanvas = new Canvas(clip);
         viewCanvas.translate(-left, -top);
         view.draw(viewCanvas);
-        var scaled = Bitmap.createScaledBitmap(clip, popup.getWidth(), popup.getHeight(), false);
+        var scaled = Bitmap.createScaledBitmap(clip, popup.getWidth(), popup.getHeight(), true);
         clip.recycle();
 
         Canvas canvas = new Canvas(dest);

--- a/editor/src/main/res/layout/magnifier_popup.xml
+++ b/editor/src/main/res/layout/magnifier_popup.xml
@@ -23,15 +23,9 @@
   ~     additional information or have any questions
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<ImageView xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:elevation="4dp"
-    android:background="@drawable/magnifier_background">
-
-    <ImageView
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:id="@+id/magnifier_image_view"/>
-
-</LinearLayout>
+    android:id="@+id/magnifier_image_view"
+    android:background="@drawable/magnifier_background" />


### PR DESCRIPTION
### 1. Improved scaled image quality
Equivalent of `setAntiAlias(true)` or `setFilterBitmap(true)`

Before:
![Screenshot_2022-06-11-14-05-13-017_io github rosemoe sora app](https://user-images.githubusercontent.com/7825871/173185343-a82ba7f0-827e-4e2a-9b1b-80520cb3dd34.jpg)

After:
![Screenshot_2022-06-11-14-03-17-739_io github rosemoe sora app](https://user-images.githubusercontent.com/7825871/173185344-b04fb69c-e8ed-444f-bc0b-4a7deb8995aa.jpg)

### 2. Improved behavior of magnifier
When using sticky selection, it will follow the cursor position if the distance between cursor and motion event more than a height of 1 char

Before:
![ezgif com-gif-maker](https://user-images.githubusercontent.com/7825871/173185757-be410c6c-31fd-4617-8649-0a49bdb86b13.gif)

After:
![ezgif com-gif-maker-2](https://user-images.githubusercontent.com/7825871/173185753-a153eebe-58c1-4cfb-982f-2f494138e915.gif)