### PR TITLE
Added KeyBIndingEvent and support for more keybindings

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -15,6 +15,7 @@
         <entry key="..\:/Users/20734/AndroidStudioProjects/sora-editor/editor/src/main/res/drawable/ic_sora_handle_drop.xml" value="0.174" />
         <entry key="..\:/Users/20734/AndroidStudioProjects/sora-editor/editor/src/main/res/layout/text_compose_panel.xml" value="0.1" />
         <entry key="..\:/Users/20734/AndroidStudioProjects/sora-editor/editor/src/main/res/layout/text_compose_popup_window.xml" value="0.1" />
+        <entry key="app/src/main/res/menu/menu_main.xml" value="0.35572916666666665" />
       </map>
     </option>
   </component>

--- a/app/src/main/java/io/github/rosemoe/sora/app/MainActivity.kt
+++ b/app/src/main/java/io/github/rosemoe/sora/app/MainActivity.kt
@@ -126,7 +126,7 @@ class MainActivity : AppCompatActivity() {
                 if (event.eventType != EditorKeyEvent.Type.DOWN) {
                     return@subscribeEvent
                 }
-                
+
                 Toast.makeText(
                     context,
                     "Keybinding event: " + generateKeybindingString(event),
@@ -312,6 +312,9 @@ class MainActivity : AppCompatActivity() {
         } else if (id == R.id.magnifier) {
             item.isChecked = !item.isChecked
             editor.getComponent(Magnifier::class.java).isEnabled = item.isChecked
+        } else if (id == R.id.useIcu) {
+            item.isChecked = !item.isChecked
+            editor.props.useICULibToSelectWords = item.isChecked
         } else if (id == R.id.code_format) {
             editor.formatCodeAsync()
         } else if (id == R.id.switch_language) {

--- a/app/src/main/java/io/github/rosemoe/sora/app/MainActivity.kt
+++ b/app/src/main/java/io/github/rosemoe/sora/app/MainActivity.kt
@@ -37,6 +37,7 @@ import androidx.activity.result.contract.ActivityResultContracts.GetContent
 import androidx.appcompat.app.AppCompatActivity
 import io.github.rosemoe.sora.app.databinding.ActivityMainBinding
 import io.github.rosemoe.sora.event.ContentChangeEvent
+import io.github.rosemoe.sora.event.KeyBindingEvent
 import io.github.rosemoe.sora.event.SelectionChangeEvent
 import io.github.rosemoe.sora.lang.EmptyLanguage
 import io.github.rosemoe.sora.lang.Language
@@ -51,7 +52,6 @@ import io.github.rosemoe.sora.widget.EditorSearcher
 import io.github.rosemoe.sora.widget.component.Magnifier
 import io.github.rosemoe.sora.widget.schemes.*
 import io.github.rosemoe.sora.widget.style.builtin.ScaleCursorAnimator
-import io.github.rosemoe.sorakt.getComponent
 import io.github.rosemoe.sorakt.subscribeEvent
 import java.io.*
 import java.util.regex.PatternSyntaxException
@@ -117,6 +117,10 @@ class MainActivity : AppCompatActivity() {
                     50
                 )
             }
+
+            subscribeEvent<KeyBindingEvent> { event, _ ->
+                Toast.makeText(context, "Keybinding event: " + generateKeybindingString(event), Toast.LENGTH_LONG).show()
+            }
         }
 
         // Custom cursor animator
@@ -145,6 +149,24 @@ class MainActivity : AppCompatActivity() {
         openAssetsFile("sample.txt")
         updatePositionText()
         updateBtnState()
+    }
+
+    private fun generateKeybindingString(event: KeyBindingEvent): String {
+        val sb = StringBuilder()
+        if (event.isCtrlPressed) {
+            sb.append("Ctrl + ")
+        }
+
+        if (event.isAltPressed) {
+            sb.append("Alt + ")
+        }
+
+        if (event.isShiftPressed) {
+            sb.append("Shift + ")
+        }
+
+        sb.append(KeyEvent.keyCodeToString(event.keyCode))
+        return sb.toString()
     }
 
     private fun openAssetsFile(name: String) {

--- a/app/src/main/java/io/github/rosemoe/sora/app/MainActivity.kt
+++ b/app/src/main/java/io/github/rosemoe/sora/app/MainActivity.kt
@@ -40,6 +40,7 @@ import androidx.activity.result.contract.ActivityResultContracts.GetContent
 import androidx.appcompat.app.AppCompatActivity
 import io.github.rosemoe.sora.app.databinding.ActivityMainBinding
 import io.github.rosemoe.sora.event.ContentChangeEvent
+import io.github.rosemoe.sora.event.EditorKeyEvent
 import io.github.rosemoe.sora.event.KeyBindingEvent
 import io.github.rosemoe.sora.event.SelectionChangeEvent
 import io.github.rosemoe.sora.lang.EmptyLanguage
@@ -122,6 +123,10 @@ class MainActivity : AppCompatActivity() {
             }
 
             subscribeEvent<KeyBindingEvent> { event, _ ->
+                if (event.eventType != EditorKeyEvent.Type.DOWN) {
+                    return@subscribeEvent
+                }
+                
                 Toast.makeText(
                     context,
                     "Keybinding event: " + generateKeybindingString(event),

--- a/app/src/main/java/io/github/rosemoe/sora/app/MainActivity.kt
+++ b/app/src/main/java/io/github/rosemoe/sora/app/MainActivity.kt
@@ -31,7 +31,10 @@ import android.net.Uri
 import android.os.Bundle
 import android.text.Editable
 import android.text.TextWatcher
-import android.view.*
+import android.view.KeyEvent
+import android.view.Menu
+import android.view.MenuItem
+import android.view.View
 import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts.GetContent
 import androidx.appcompat.app.AppCompatActivity
@@ -119,7 +122,11 @@ class MainActivity : AppCompatActivity() {
             }
 
             subscribeEvent<KeyBindingEvent> { event, _ ->
-                Toast.makeText(context, "Keybinding event: " + generateKeybindingString(event), Toast.LENGTH_LONG).show()
+                Toast.makeText(
+                    context,
+                    "Keybinding event: " + generateKeybindingString(event),
+                    Toast.LENGTH_LONG
+                ).show()
             }
         }
 
@@ -196,10 +203,26 @@ class MainActivity : AppCompatActivity() {
     private fun updatePositionText() {
         val cursor = binding.editor.cursor
         var text = (1 + cursor.leftLine).toString() + ":" + cursor.leftColumn
-        if (cursor.isSelected) {
-            text += "(" + (cursor.right - cursor.left) + " chars)"
+        text += if (cursor.isSelected) {
+            "(" + (cursor.right - cursor.left) + " chars)"
+        } else {
+            "(" + escapeIfNecessary(
+                binding.editor.text.charAt(
+                    cursor.leftLine,
+                    cursor.leftColumn
+                )
+            ) + ")"
         }
         binding.positionDisplay.text = text
+    }
+
+    private fun escapeIfNecessary(c: Char): String {
+        return when (c) {
+            '\n' -> "\\n"
+            '\t' -> "\\t"
+            ' ' -> "<ws>"
+            else -> c.toString()
+        }
     }
 
     private val loadTMLLauncher = registerForActivityResult(GetContent()) { result: Uri? ->
@@ -225,6 +248,7 @@ class MainActivity : AppCompatActivity() {
             e.printStackTrace()
         }
     }
+
     private val loadTMTLauncher = registerForActivityResult(GetContent()) { result: Uri? ->
         try {
             if (result == null) return@registerForActivityResult

--- a/app/src/main/res/menu/menu_main.xml
+++ b/app/src/main/res/menu/menu_main.xml
@@ -80,6 +80,11 @@
                 android:checkable="true"
                 android:checked="true"
                 android:title="@string/magnifier"/>
+            <item
+                android:id="@+id/useIcu"
+                android:checkable="true"
+                android:checked="true"
+                android:title="@string/use_icu_library"/>
         </menu>
     </item>
     <item

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -60,4 +60,5 @@
     <string name="pin_line_number">Pin LineNumber</string>
     <string name="feature_switches">Feature Switches</string>
     <string name="magnifier">Magnifier</string>
+    <string name="use_icu_library">Use ICU library</string>
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.3.0-beta03'
+        classpath 'com.android.tools.build:gradle:7.4.0-alpha03'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.0-alpha03'
+        classpath 'com.android.tools.build:gradle:7.3.0-beta03'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/editor/src/main/java/io/github/rosemoe/sora/event/EditorKeyEvent.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/event/EditorKeyEvent.java
@@ -42,10 +42,12 @@ import io.github.rosemoe.sora.widget.CodeEditor;
 public class EditorKeyEvent extends ResultedEvent<Boolean> {
 
     private final KeyEvent src;
+    private final Type type;
 
-    public EditorKeyEvent(CodeEditor editor, KeyEvent src) {
+    public EditorKeyEvent(CodeEditor editor, KeyEvent src, Type type) {
         super(editor);
         this.src = src;
+        this.type = type;
     }
 
     public int getAction() {
@@ -70,6 +72,15 @@ public class EditorKeyEvent extends ResultedEvent<Boolean> {
 
     public long getDownTime() {
         return src.getDownTime();
+    }
+
+    /**
+     * Get the key event type.
+     *
+     * @return The key event type.
+     */
+    public Type getEventType() {
+        return this.type;
     }
 
     @Override
@@ -102,5 +113,26 @@ public class EditorKeyEvent extends ResultedEvent<Boolean> {
         } else {
             return userResult || editorResult;
         }
+    }
+
+    /**
+     * The type of an {@link EditorKeyEvent}.
+     */
+    public enum Type {
+
+        /**
+         * Used for {@link CodeEditor#onKeyUp(int, KeyEvent)}.
+         */
+        UP,
+
+        /**
+         * Used for {@link CodeEditor#onKeyDown(int, KeyEvent)}.
+         */
+        DOWN,
+
+        /**
+         * Used for {@link CodeEditor#onKeyMultiple(int, int, KeyEvent)}.
+         */
+        MULTIPLE
     }
 }

--- a/editor/src/main/java/io/github/rosemoe/sora/event/EditorKeyEvent.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/event/EditorKeyEvent.java
@@ -31,13 +31,13 @@ import io.github.rosemoe.sora.widget.CodeEditor;
  * Receives key related events in editor.
  * <p>
  * You may set a boolean for editor to return to the Android KeyEvent framework.
+ *
+ * @author Rosemoe
  * @see ResultedEvent#setResult(Object)
  * <p>
  * This class mirrors methods of {@link KeyEvent}, but some methods are changed:
  * @see #isAltPressed()
  * @see #isShiftPressed()
- *
- * @author Rosemoe
  */
 public class EditorKeyEvent extends ResultedEvent<Boolean> {
 

--- a/editor/src/main/java/io/github/rosemoe/sora/event/KeyBindingEvent.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/event/KeyBindingEvent.java
@@ -56,10 +56,12 @@ public class KeyBindingEvent extends EditorKeyEvent {
      *
      * @param editor          The editor.
      * @param src             The source {@link KeyEvent}.
+     * @param keyCode         The key code.
+     * @param type            The key event type.
      * @param canEditorHandle <code>true</code> if the editor can handle this event, <code>false</code> otherwise.
      */
-    public KeyBindingEvent(CodeEditor editor, KeyEvent src, int keyCode, boolean canEditorHandle) {
-        super(editor, src);
+    public KeyBindingEvent(CodeEditor editor, KeyEvent src, Type type, int keyCode, boolean canEditorHandle) {
+        super(editor, src, type);
         this.keyCode = keyCode;
         this.canEditorHandle = canEditorHandle;
     }

--- a/editor/src/main/java/io/github/rosemoe/sora/event/KeyBindingEvent.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/event/KeyBindingEvent.java
@@ -1,0 +1,75 @@
+/*
+ *    sora-editor - the awesome code editor for Android
+ *    https://github.com/Rosemoe/sora-editor
+ *    Copyright (C) 2020-2022  Rosemoe
+ *
+ *     This library is free software; you can redistribute it and/or
+ *     modify it under the terms of the GNU Lesser General Public
+ *     License as published by the Free Software Foundation; either
+ *     version 2.1 of the License, or (at your option) any later version.
+ *
+ *     This library is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *     Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public
+ *     License along with this library; if not, write to the Free Software
+ *     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *     USA
+ *
+ *     Please contact Rosemoe by email 2073412493@qq.com if you need
+ *     additional information or have any questions
+ */
+package io.github.rosemoe.sora.event;
+
+import android.view.KeyEvent;
+
+import io.github.rosemoe.sora.widget.CodeEditor;
+
+/**
+ * Keybinding event in editor.
+ *
+ * <p> This is different from {@link EditorKeyEvent}.
+ * An {@code EditorKeyEvent} is dispatched by the editor whenever there is a key event.
+ * However, a {@code KeyBindingEvent} is dispatched only for keybindings i.e.
+ * when multiple keys are pressed at once.
+ * For example, <b>Ctrl + X, Ctrl + D, Ctrl + Alt + O, etc.</b>
+ * </p>
+ *
+ * <p>
+ * This event is dispatched <strong>after</strong> the {@link EditorKeyEvent}.
+ * So, if any {@code EditorKeyEvent} consumes the event (sets the {@link InterceptTarget#TARGET_EDITOR} flag),
+ * {@code KeyBindingEvent} will not be called.
+ * </p>
+ *
+ * @author Akash Yadav
+ */
+public class KeyBindingEvent extends EditorKeyEvent {
+
+    // TODO This should be renamed.
+    private final boolean canEditorHandle;
+    private final int keyCode;
+
+    /**
+     * Creates a new {@code KeyBindingEvent} instance.
+     *
+     * @param editor          The editor.
+     * @param src             The source {@link KeyEvent}.
+     * @param canEditorHandle <code>true</code> if the editor can handle this event, <code>false</code> otherwise.
+     */
+    public KeyBindingEvent(CodeEditor editor, KeyEvent src, int keyCode, boolean canEditorHandle) {
+        super(editor, src);
+        this.keyCode = keyCode;
+        this.canEditorHandle = canEditorHandle;
+    }
+
+    /**
+     * Is the editor capable of handling this key binding event?
+     *
+     * @return <code>true</code> if the editor can handle this event. <code>false</code> otherwise.
+     */
+    public boolean canEditorHandle() {
+        return this.canEditorHandle;
+    }
+}

--- a/editor/src/main/java/io/github/rosemoe/sora/text/ICUUtils.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/text/ICUUtils.java
@@ -43,8 +43,8 @@ public class ICUUtils {
      * @param offset Required char offset of word
      * @return Packed value of (start, end) pair. Always contains the position {@code offset}
      */
-    public static long getWordEdges(CharSequence text, int offset) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+    public static long getWordEdges(CharSequence text, int offset, boolean useIcu) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && useIcu) {
             var itr = BreakIterator.getWordInstance();
             itr.setText(new CharSequenceIterator(text));
             int end = itr.following(offset);
@@ -62,7 +62,7 @@ public class ICUUtils {
     /**
      * Primitive implementation of {@link #getWordEdges(CharSequence, int)}
      */
-    private static long getWordEdgesFallback(CharSequence text, int offset) {
+    public static long getWordEdgesFallback(CharSequence text, int offset) {
         int start = offset;
         int end = offset;
         while (start > 0 && MyCharacter.isJavaIdentifierPart(text.charAt(start - 1))) {

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/CodeEditor.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/CodeEditor.java
@@ -888,8 +888,14 @@ public class CodeEditor extends View implements ContentListener, StyleReceiver, 
                     || keyCode == KeyEvent.KEYCODE_D || keyCode == KeyEvent.KEYCODE_W;
         }
 
-        if (shiftPressed && !ctrlPressed && !altPressed) {
-            return keyCode == KeyEvent.KEYCODE_ENTER;
+        if (shiftPressed && !altPressed) {
+            if (ctrlPressed) {
+                // Ctrl + Shift + J
+                return keyCode == KeyEvent.KEYCODE_J;
+            } else {
+                // Shift + Enter
+                return keyCode == KeyEvent.KEYCODE_ENTER;
+            }
         }
 
         return false;

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/CodeEditor.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/CodeEditor.java
@@ -883,7 +883,7 @@ public class CodeEditor extends View implements ContentListener, StyleReceiver, 
                 && (keyCode == KeyEvent.KEYCODE_A || keyCode == KeyEvent.KEYCODE_C
                 || keyCode == KeyEvent.KEYCODE_X || keyCode == KeyEvent.KEYCODE_V
                 || keyCode == KeyEvent.KEYCODE_U || keyCode == KeyEvent.KEYCODE_R
-                || keyCode == KeyEvent.KEYCODE_D);
+                || keyCode == KeyEvent.KEYCODE_D || keyCode == KeyEvent.KEYCODE_W);
     }
 
     /**

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/CodeEditor.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/CodeEditor.java
@@ -2894,9 +2894,19 @@ public class CodeEditor extends View implements ContentListener, StyleReceiver, 
     }
 
     /**
-     * Copy text to clip board
+     * Copy text to clipboard.
      */
     public void copyText() {
+        copyText(true);
+    }
+
+    /**
+     * Copy text to clipboard.
+     *
+     * @param shouldSelectLine State whether the editor should select whole line if
+     *                         cursor is not in selection mode.
+     */
+    public void copyText(boolean shouldSelectLine) {
         try {
             if (mCursor.isSelected()) {
                 String clip = getText().subContent(mCursor.getLeftLine(),
@@ -2904,7 +2914,7 @@ public class CodeEditor extends View implements ContentListener, StyleReceiver, 
                         mCursor.getRightLine(),
                         mCursor.getRightColumn()).toString();
                 mClipboardManager.setPrimaryClip(ClipData.newPlainText(clip, clip));
-            } else {
+            } else if (shouldSelectLine) {
                 copyLine();
             }
         } catch (Exception e) {
@@ -2932,8 +2942,8 @@ public class CodeEditor extends View implements ContentListener, StyleReceiver, 
      * Copy text to clipboard and delete them
      */
     public void cutText() {
-        copyText();
         if (mCursor.isSelected()) {
+            copyText();
             deleteText();
             notifyIMEExternalCursorChange();
         } else {
@@ -2955,7 +2965,7 @@ public class CodeEditor extends View implements ContentListener, StyleReceiver, 
         final var line = left.line;
         final var column = getText().getColumnCount(left.line);
 
-        if (line + 1 == getText().getLineCount()) {
+        if (line + 1 == getLineCount()) {
             setSelectionRegion(line, 0, line, getText().getColumnCount(line));
         } else {
             setSelectionRegion(line, 0, line + 1, 0);

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/CodeEditor.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/CodeEditor.java
@@ -3761,6 +3761,15 @@ public class CodeEditor extends View implements ContentListener, StyleReceiver, 
                     notifyIMEExternalCursorChange();
                 }
                 return e.result(true);
+            case KeyEvent.KEYCODE_ESCAPE :
+                final var cursor = getCursor();
+                if (cursor.isSelected()) {
+                    // TODO Maybe we could add a flag in DirectAccessProps to change this behaviour
+                    //    So that user can select whether left or right cursor should be selected
+                    final var left = cursor.right();
+                    setSelection(left.line, left.column, true);
+                }
+                return e.result(true);
             default:
                 if (event.isCtrlPressed() && !event.isAltPressed()) {
                     switch (keyCode) {

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/CodeEditor.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/CodeEditor.java
@@ -2923,7 +2923,32 @@ public class CodeEditor extends View implements ContentListener, StyleReceiver, 
         if (mCursor.isSelected()) {
             deleteText();
             notifyIMEExternalCursorChange();
+        } else {
+            cutLine();
         }
+    }
+
+    /**
+     * Copy the current line to clipboard and delete it.
+     */
+    public void cutLine() {
+        final var cursor = getCursor();
+        if (cursor.isSelected()) {
+            cutText();
+            return;
+        }
+
+        final var left = cursor.left();
+        final var line = left.line;
+        final var column = getText().getColumnCount(left.line);
+
+        if (line + 1 == getText().getLineCount()) {
+            // Should not cut text if the cursor is alt the last line of content
+            return;
+        }
+
+        setSelectionRegion(line, 0, line + 1, 0);
+        cutText();
     }
 
     /**
@@ -2938,7 +2963,7 @@ public class CodeEditor extends View implements ContentListener, StyleReceiver, 
         }
 
         final var left = cursor.left();
-        setSelectionRegion(left.line, 0, left.line, getText().getLineString(left.line).length(), true);
+        setSelectionRegion(left.line, 0, left.line, getText().getColumnCount(left.line), true);
         duplicateSelection("\n", false);
     }
 
@@ -2952,6 +2977,7 @@ public class CodeEditor extends View implements ContentListener, StyleReceiver, 
 
     /**
      * Copies the current selection and pastes it at the right selection handle.
+     *
      * @param selectDuplicate Whether to select the duplicated content.
      */
     public void duplicateSelection(boolean selectDuplicate) {
@@ -2962,7 +2988,7 @@ public class CodeEditor extends View implements ContentListener, StyleReceiver, 
      * Copies the current selection, add the <code>prefix</code> to it
      * and pastes it at the right selection handle.
      *
-     * @param prefix The prefix for the selected content.
+     * @param prefix          The prefix for the selected content.
      * @param selectDuplicate Whether to select the duplicated content.
      */
     public void duplicateSelection(String prefix, boolean selectDuplicate) {

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/CodeEditor.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/CodeEditor.java
@@ -874,16 +874,25 @@ public class CodeEditor extends View implements ContentListener, StyleReceiver, 
      * Internal callback to check if the editor is capable of handling the given
      * keybinding {@link KeyEvent}
      *
-     * @param keyCode The keycode for the keybinding event.
-     * @param event   The {@link KeyEvent} for the keybinding.
+     * @param keyCode      The keycode for the keybinding event.
+     * @param ctrlPressed  Is 'Ctrl' key pressed?
+     * @param shiftPressed Is 'Shift' key pressed?
+     * @param altPressed   Is 'Alt' key pressed?
      * @return <code>true</code> if the editor can handle the keybinding, <code>false</code> otherwise.
      */
-    protected boolean canHandleKeyBinding(int keyCode, @NonNull KeyEvent event) {
-        return event.isCtrlPressed()
-                && (keyCode == KeyEvent.KEYCODE_A || keyCode == KeyEvent.KEYCODE_C
-                || keyCode == KeyEvent.KEYCODE_X || keyCode == KeyEvent.KEYCODE_V
-                || keyCode == KeyEvent.KEYCODE_U || keyCode == KeyEvent.KEYCODE_R
-                || keyCode == KeyEvent.KEYCODE_D || keyCode == KeyEvent.KEYCODE_W);
+    protected boolean canHandleKeyBinding(int keyCode, boolean ctrlPressed, boolean shiftPressed, boolean altPressed) {
+        if (ctrlPressed && !shiftPressed && altPressed) {
+            return keyCode == KeyEvent.KEYCODE_A || keyCode == KeyEvent.KEYCODE_C
+                    || keyCode == KeyEvent.KEYCODE_X || keyCode == KeyEvent.KEYCODE_V
+                    || keyCode == KeyEvent.KEYCODE_U || keyCode == KeyEvent.KEYCODE_R
+                    || keyCode == KeyEvent.KEYCODE_D || keyCode == KeyEvent.KEYCODE_W;
+        }
+
+        if (shiftPressed && !ctrlPressed && !altPressed) {
+            return keyCode == KeyEvent.KEYCODE_ENTER;
+        }
+
+        return false;
     }
 
     /**

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/CodeEditor.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/CodeEditor.java
@@ -2903,10 +2903,10 @@ public class CodeEditor extends View implements ContentListener, StyleReceiver, 
     /**
      * Copy text to clipboard.
      *
-     * @param shouldSelectLine State whether the editor should select whole line if
+     * @param shouldCopyLine State whether the editor should select whole line if
      *                         cursor is not in selection mode.
      */
-    public void copyText(boolean shouldSelectLine) {
+    public void copyText(boolean shouldCopyLine) {
         try {
             if (mCursor.isSelected()) {
                 String clip = getText().subContent(mCursor.getLeftLine(),
@@ -2914,7 +2914,7 @@ public class CodeEditor extends View implements ContentListener, StyleReceiver, 
                         mCursor.getRightLine(),
                         mCursor.getRightColumn()).toString();
                 mClipboardManager.setPrimaryClip(ClipData.newPlainText(clip, clip));
-            } else if (shouldSelectLine) {
+            } else if (shouldCopyLine) {
                 copyLine();
             }
         } catch (Exception e) {

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/CodeEditor.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/CodeEditor.java
@@ -2908,11 +2908,28 @@ public class CodeEditor extends View implements ContentListener, StyleReceiver, 
                         mCursor.getRightLine(),
                         mCursor.getRightColumn()).toString();
                 mClipboardManager.setPrimaryClip(ClipData.newPlainText(clip, clip));
+            } else {
+                copyLine();
             }
         } catch (Exception e) {
             e.printStackTrace();
             Toast.makeText(getContext(), e.toString(), Toast.LENGTH_SHORT).show();
         }
+    }
+
+    /**
+     * Copies the current line to clipboard.
+     */
+    private void copyLine() {
+        final var cursor = getCursor();
+        if (cursor.isSelected()) {
+            copyText();
+            return;
+        }
+
+        final var line = cursor.left().line;
+        setSelectionRegion(line, 0, line, getText().getColumnCount(line));
+        copyText();
     }
 
     /**

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/CodeEditor.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/CodeEditor.java
@@ -2960,11 +2960,11 @@ public class CodeEditor extends View implements ContentListener, StyleReceiver, 
         final var column = getText().getColumnCount(left.line);
 
         if (line + 1 == getText().getLineCount()) {
-            // Should not cut text if the cursor is alt the last line of content
-            return;
+            setSelectionRegion(line, 0, line, getText().getColumnCount(line));
+        } else {
+            setSelectionRegion(line, 0, line + 1, 0);
         }
 
-        setSelectionRegion(line, 0, line + 1, 0);
         cutText();
     }
 

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/CodeEditor.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/CodeEditor.java
@@ -2904,7 +2904,7 @@ public class CodeEditor extends View implements ContentListener, StyleReceiver, 
      * Copy text to clipboard.
      *
      * @param shouldCopyLine State whether the editor should select whole line if
-     *                         cursor is not in selection mode.
+     *                       cursor is not in selection mode.
      */
     public void copyText(boolean shouldCopyLine) {
         try {
@@ -3051,7 +3051,7 @@ public class CodeEditor extends View implements ContentListener, StyleReceiver, 
         // Find word edges
         int startLine = line, endLine = line;
         var lineObj = getText().getLine(line);
-        long edges = ICUUtils.getWordEdges(lineObj, column);
+        long edges = ICUUtils.getWordEdges(lineObj, column, mProps.useICULibToSelectWords);
         int startColumn = IntPair.getFirst(edges);
         int endColumn = IntPair.getSecond(edges);
         if (startColumn == endColumn) {

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/DirectAccessProps.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/DirectAccessProps.java
@@ -36,7 +36,7 @@ import io.github.rosemoe.sora.annotations.InvalidateRequired;
 
 /**
  * Direct-access properties.
- *
+ * <p>
  * This object saves some feature settings of editor. These features are not accessed unless the user
  * does something that requires to check the state of the feature. So we save them here by public fields
  * so that you can modify them easily and do not have to call so many methods.
@@ -46,7 +46,7 @@ public class DirectAccessProps implements Serializable {
     /**
      * If set to be true, the editor will delete the whole line if the current line is empty (only tabs or spaces)
      * when the users press the DELETE key.
-     *
+     * <p>
      * Default value is {@code true}
      */
     public boolean deleteEmptyLineFast = true;
@@ -54,7 +54,7 @@ public class DirectAccessProps implements Serializable {
     /**
      * Delete multiple spaces at a time when the user press the DELETE key.
      * This only takes effect when selection is in leading spaces.
-     *
+     * <p>
      * Default Value: {@code 1}  -> The editor will always delete only 1 space.
      * Special Value: {@code -1} -> Follow tab size
      */
@@ -70,14 +70,14 @@ public class DirectAccessProps implements Serializable {
 
     /**
      * Control whether auto-completes for symbol pairs.
-     *
+     * <p>
      * Such as automatically adding a ')' when '(' is entered
      */
     public boolean symbolPairAutoCompletion = true;
 
     /**
      * Show auto-completion even when there is composing text set by the IME in editor.
-     *
+     * <p>
      * Note: composing text is usually a small piece of text you are typing. It is displayed with an
      * underline in editor.
      * This is useful when the user uses an input method that does not support the attitude {@link EditorInfo#TYPE_TEXT_FLAG_NO_SUGGESTIONS}.
@@ -89,7 +89,7 @@ public class DirectAccessProps implements Serializable {
     /**
      * Set whether auto indent should be executed when user enters
      * a NEWLINE.
-     *
+     * <p>
      * Enabling this will automatically copy the leading spaces on this line to the new line.
      */
     public boolean autoIndent = true;
@@ -158,7 +158,7 @@ public class DirectAccessProps implements Serializable {
 
     /**
      * Wave length of problem indicators.
-     *
+     * <p>
      * Unit DIP.
      */
     @InvalidateRequired
@@ -167,7 +167,7 @@ public class DirectAccessProps implements Serializable {
 
     /**
      * Wave width of problem indicators.
-     *
+     * <p>
      * Unit DIP.
      */
     @InvalidateRequired
@@ -176,7 +176,7 @@ public class DirectAccessProps implements Serializable {
 
     /**
      * Wave amplitude of problem indicators.
-     *
+     * <p>
      * Unit DIP.
      */
     @InvalidateRequired
@@ -185,7 +185,7 @@ public class DirectAccessProps implements Serializable {
 
     /**
      * Compare the text to commit with composing text.
-     *
+     * <p>
      * See detailed issue: #155
      */
     public boolean trackComposingTextOnCommit = true;
@@ -201,5 +201,10 @@ public class DirectAccessProps implements Serializable {
      * This costs some memory, but improves performance.
      */
     public boolean cacheRenderNodeForLongLines = true;
+
+    /**
+     * Use the ICU library to find range of words on double tap or long press.
+     */
+    public boolean useICULibToSelectWords = true;
 
 }

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/EditorInputConnection.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/EditorInputConnection.java
@@ -583,7 +583,7 @@ class EditorInputConnection extends BaseInputConnection {
 
     @Override
     public boolean clearMetaKeyStates(int states) {
-        mEditor.mKeyMetaStates.clearMetaStates(states);
+        mEditor.getKeyMetaStates().clearMetaStates(states);
         return true;
     }
 

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/EditorKeyEventHandler.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/EditorKeyEventHandler.java
@@ -74,8 +74,7 @@ class EditorKeyEventHandler {
         return (mKeyMetaStates.isShiftPressed()
                 || mKeyMetaStates.isAltPressed()
                 || event.isCtrlPressed())
-                && keyCode >= KeyEvent.KEYCODE_A
-                && keyCode <= KeyEvent.KEYCODE_Z;
+                && ((keyCode >= KeyEvent.KEYCODE_A && keyCode <= KeyEvent.KEYCODE_Z) || keyCode == KeyEvent.KEYCODE_ENTER);
     }
 
     /**
@@ -119,7 +118,7 @@ class EditorKeyEventHandler {
                             event,
                             EditorKeyEvent.Type.DOWN,
                             keyCode,
-                            editor.canHandleKeyBinding(keyCode, event));
+                            editor.canHandleKeyBinding(keyCode, event.isCtrlPressed(), mKeyMetaStates.isShiftPressed(), mKeyMetaStates.isAltPressed()));
 
             if ((eventManager.dispatchEvent(keybindingEvent) & InterceptTarget.TARGET_EDITOR) != 0) {
                 return keybindingEvent.result(false);
@@ -169,6 +168,15 @@ class EditorKeyEventHandler {
                         completionWindow.select();
                         return true;
                     }
+
+                    if (isShiftPressed) {
+                        final var line = editorCursor.right().line;
+                        editor.setSelection(line, editorText.getColumnCount(line));
+                        editor.commitText("\n");
+                        editor.ensureSelectionVisible();
+                        return e.result(true);
+                    }
+
                     NewlineHandler[] handlers = editorLanguage.getNewlineHandlers();
                     if (handlers == null || editorCursor.isSelected()) {
                         editor.commitText("\n", true);
@@ -374,7 +382,7 @@ class EditorKeyEventHandler {
                             event,
                             EditorKeyEvent.Type.UP,
                             keyCode,
-                            editor.canHandleKeyBinding(keyCode, event));
+                            editor.canHandleKeyBinding(keyCode, event.isCtrlPressed(), mKeyMetaStates.isShiftPressed(), mKeyMetaStates.isAltPressed()));
 
             if ((eventManager.dispatchEvent(keybindingEvent) & InterceptTarget.TARGET_EDITOR) != 0) {
                 return keybindingEvent.result(false);

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/EditorKeyEventHandler.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/EditorKeyEventHandler.java
@@ -108,7 +108,9 @@ class EditorKeyEventHandler {
             return e.result(false);
         }
 
-        boolean isShiftPressed = mKeyMetaStates.isShiftPressed();
+        final var isShiftPressed = mKeyMetaStates.isShiftPressed();
+        final var isAltPressed = mKeyMetaStates.isAltPressed();
+        final var isCtrlPressed = event.isCtrlPressed();
 
         // Currently, KeyBindingEvent is triggered only for (Shift | Ctrl | Alt) + alphabet keys
         // Should we add support for more keys?
@@ -169,10 +171,18 @@ class EditorKeyEventHandler {
                         return true;
                     }
 
-                    if (isShiftPressed) {
+                    if (isShiftPressed && !isAltPressed && !isCtrlPressed) {
                         final var line = editorCursor.right().line;
                         editor.setSelection(line, editorText.getColumnCount(line));
                         editor.commitText("\n");
+                        editor.ensureSelectionVisible();
+                        return e.result(true);
+                    }
+
+                    if (isCtrlPressed && !isShiftPressed && !isAltPressed) {
+                        final var left = editorCursor.left().fromThis();
+                        editor.commitText("\n");
+                        editor.setSelection(left.line, left.column);
                         editor.ensureSelectionVisible();
                         return e.result(true);
                     }

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/EditorKeyEventHandler.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/EditorKeyEventHandler.java
@@ -122,7 +122,7 @@ class EditorKeyEventHandler {
         // Should we add support for more keys?
         if (isKeyBindingEvent(keyCode, event)) {
             if ((eventManager.dispatchEvent(keybindingEvent) & InterceptTarget.TARGET_EDITOR) != 0) {
-                return keybindingEvent.result(false) || e.result(true);
+                return keybindingEvent.result(false) || e.result(false);
             }
         }
 
@@ -175,7 +175,7 @@ class EditorKeyEventHandler {
                         editor.setSelection(line, editorText.getColumnCount(line));
                         editor.commitText("\n");
                         editor.ensureSelectionVisible();
-                        return keybindingEvent.result(true) || e.result(false);
+                        return keybindingEvent.result(true) || e.result(true);
                     }
 
                     if (isCtrlPressed && !isShiftPressed && !isAltPressed) {
@@ -183,7 +183,7 @@ class EditorKeyEventHandler {
                         editor.commitText("\n");
                         editor.setSelection(left.line, left.column);
                         editor.ensureSelectionVisible();
-                        return keybindingEvent.result(true) || e.result(false);
+                        return keybindingEvent.result(true) || e.result(true);
                     }
 
                     NewlineHandler[] handlers = editorLanguage.getNewlineHandlers();
@@ -289,38 +289,48 @@ class EditorKeyEventHandler {
                             if (editor.isEditable()) {
                                 editor.pasteText();
                             }
-                            return keybindingEvent.result(true) || e.result(false);
+                            return keybindingEvent.result(true) || e.result(true);
                         case KeyEvent.KEYCODE_C:
                             editor.copyText();
-                            return keybindingEvent.result(true) || e.result(false);
+                            return keybindingEvent.result(true) || e.result(true);
                         case KeyEvent.KEYCODE_X:
                             if (editor.isEditable()) {
                                 editor.cutText();
                             } else {
                                 editor.copyText();
                             }
-                            return keybindingEvent.result(true) || e.result(false);
+                            return keybindingEvent.result(true) || e.result(true);
                         case KeyEvent.KEYCODE_A:
                             editor.selectAll();
-                            return keybindingEvent.result(true) || e.result(false);
+                            return keybindingEvent.result(true) || e.result(true);
                         case KeyEvent.KEYCODE_Z:
                             if (editor.isEditable()) {
                                 editor.undo();
                             }
-                            return keybindingEvent.result(true) || e.result(false);
+                            return keybindingEvent.result(true) || e.result(true);
                         case KeyEvent.KEYCODE_Y:
                             if (editor.isEditable()) {
                                 editor.redo();
                             }
-                            return keybindingEvent.result(true) || e.result(false);
+                            return keybindingEvent.result(true) || e.result(true);
                         case KeyEvent.KEYCODE_D:
                             if (editor.isEditable()) {
                                 editor.duplicateLine();
                             }
-                            return keybindingEvent.result(true) || e.result(false);
+                            return keybindingEvent.result(true) || e.result(true);
                         case KeyEvent.KEYCODE_W:
                             editor.selectCurrentWord();
-                            return keybindingEvent.result(true) || e.result(false);
+                            return keybindingEvent.result(true) || e.result(true);
+                        case KeyEvent.KEYCODE_J:
+                            if (!isShiftPressed || editorCursor.isSelected()) {
+                                return keybindingEvent.result(false) || e.result(false);
+                            }
+
+                            final var line = editorCursor.getLeftLine();
+                            editor.setSelection(line, editorText.getColumnCount(line));
+                            connection.deleteSurroundingText(0, 1);
+                            editor.ensureSelectionVisible();
+                            return keybindingEvent.result(true) || e.result(true);
                     }
                 } else if (!event.isCtrlPressed() && !event.isAltPressed()) {
                     if (event.isPrintingKey() && editor.isEditable()) {

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/EditorKeyEventHandler.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/EditorKeyEventHandler.java
@@ -301,6 +301,9 @@ class EditorKeyEventHandler {
                                 editor.duplicateLine();
                             }
                             return e.result(true);
+                        case KeyEvent.KEYCODE_W:
+                            editor.selectCurrentWord();
+                            return e.result(true);
                     }
                 } else if (!event.isCtrlPressed() && !event.isAltPressed()) {
                     if (event.isPrintingKey() && editor.isEditable()) {

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/EditorKeyEventHandler.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/EditorKeyEventHandler.java
@@ -323,6 +323,7 @@ class EditorKeyEventHandler {
                             return keybindingEvent.result(true) || e.result(true);
                         case KeyEvent.KEYCODE_J:
                             if (!isShiftPressed || editorCursor.isSelected()) {
+                                // TODO If the cursor is selected, then the selected lines must be joined.
                                 return keybindingEvent.result(false) || e.result(false);
                             }
 

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/EditorKeyEventHandler.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/EditorKeyEventHandler.java
@@ -31,7 +31,6 @@ import androidx.annotation.NonNull;
 import java.util.Objects;
 
 import io.github.rosemoe.sora.event.EditorKeyEvent;
-import io.github.rosemoe.sora.event.EventManager;
 import io.github.rosemoe.sora.event.InterceptTarget;
 import io.github.rosemoe.sora.event.KeyBindingEvent;
 import io.github.rosemoe.sora.lang.smartEnter.NewlineHandleResult;
@@ -105,7 +104,7 @@ class EditorKeyEventHandler {
         final var editorText = editor.getText();
         final var completionWindow = editor.getComponent(EditorAutoCompletion.class);
 
-        var e = new EditorKeyEvent(editor, event);
+        var e = new EditorKeyEvent(editor, event, EditorKeyEvent.Type.DOWN);
         if ((eventManager.dispatchEvent(e) & InterceptTarget.TARGET_EDITOR) != 0) {
             return e.result(false);
         }
@@ -115,7 +114,13 @@ class EditorKeyEventHandler {
         // Currently, KeyBindingEvent is triggered only for (Shift | Ctrl | Alt) + alphabet keys
         // Should we add support for more keys?
         if (isKeyBindingEvent(keyCode, event)) {
-            final var keybindingEvent = new KeyBindingEvent(editor, event, keyCode, editor.canHandleKeyBinding(keyCode, event));
+            final var keybindingEvent =
+                    new KeyBindingEvent(editor,
+                            event,
+                            EditorKeyEvent.Type.DOWN,
+                            keyCode,
+                            editor.canHandleKeyBinding(keyCode, event));
+
             if ((eventManager.dispatchEvent(keybindingEvent) & InterceptTarget.TARGET_EDITOR) != 0) {
                 return keybindingEvent.result(false);
             }
@@ -355,13 +360,19 @@ class EditorKeyEventHandler {
         final var eventManager = this.editor.mEventManager;
         final var cursor = this.editor.getCursor();
 
-        var e = new EditorKeyEvent(this.editor, event);
+        var e = new EditorKeyEvent(this.editor, event, EditorKeyEvent.Type.UP);
         if ((eventManager.dispatchEvent(e) & InterceptTarget.TARGET_EDITOR) != 0) {
             return e.result(false);
         }
 
         if (isKeyBindingEvent(keyCode, event)) {
-            final var keybindingEvent = new KeyBindingEvent(editor, event, keyCode, editor.canHandleKeyBinding(keyCode, event));
+            final var keybindingEvent =
+                    new KeyBindingEvent(editor,
+                            event,
+                            EditorKeyEvent.Type.UP,
+                            keyCode,
+                            editor.canHandleKeyBinding(keyCode, event));
+
             if ((eventManager.dispatchEvent(keybindingEvent) & InterceptTarget.TARGET_EDITOR) != 0) {
                 return keybindingEvent.result(false);
             }
@@ -383,7 +394,7 @@ class EditorKeyEventHandler {
      * @return <code>true</code> if the event was handled, <code>false</code> otherwise.
      */
     public boolean onKeyMultiple(int keyCode, int repeatCount, @NonNull KeyEvent event) {
-        final var e = new EditorKeyEvent(this.editor, event);
+        final var e = new EditorKeyEvent(this.editor, event, EditorKeyEvent.Type.MULTIPLE);
         final var eventManager = this.editor.mEventManager;
         if ((eventManager.dispatchEvent(e) & InterceptTarget.TARGET_EDITOR) != 0) {
             return e.result(false);

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/EditorKeyEventHandler.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/EditorKeyEventHandler.java
@@ -1,0 +1,367 @@
+/*
+ *    sora-editor - the awesome code editor for Android
+ *    https://github.com/Rosemoe/sora-editor
+ *    Copyright (C) 2020-2022  Rosemoe
+ *
+ *     This library is free software; you can redistribute it and/or
+ *     modify it under the terms of the GNU Lesser General Public
+ *     License as published by the Free Software Foundation; either
+ *     version 2.1 of the License, or (at your option) any later version.
+ *
+ *     This library is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *     Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public
+ *     License along with this library; if not, write to the Free Software
+ *     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *     USA
+ *
+ *     Please contact Rosemoe by email 2073412493@qq.com if you need
+ *     additional information or have any questions
+ */
+package io.github.rosemoe.sora.widget;
+
+import android.util.Log;
+import android.view.KeyEvent;
+
+import androidx.annotation.NonNull;
+
+import java.util.Objects;
+
+import io.github.rosemoe.sora.event.EditorKeyEvent;
+import io.github.rosemoe.sora.event.InterceptTarget;
+import io.github.rosemoe.sora.event.KeyBindingEvent;
+import io.github.rosemoe.sora.lang.smartEnter.NewlineHandleResult;
+import io.github.rosemoe.sora.lang.smartEnter.NewlineHandler;
+import io.github.rosemoe.sora.text.CharPosition;
+import io.github.rosemoe.sora.text.ContentLine;
+import io.github.rosemoe.sora.widget.component.EditorAutoCompletion;
+
+/**
+ * Handles {@link KeyEvent}s in editor.
+ *
+ * <p>
+ * <strong>This is for internal use only.</strong>
+ * </p>
+ *
+ * @author Rose
+ * @author Akash Yadav
+ */
+class EditorKeyEventHandler {
+
+    private final CodeEditor editor;
+    private final KeyMetaStates mKeyMetaStates;
+    private static final String TAG = "EditorKeyEventHandler";
+
+    EditorKeyEventHandler(CodeEditor editor) {
+        Objects.requireNonNull(editor, "Cannot setup KeyEvent with null editor instance.");
+        this.editor = editor;
+        this.mKeyMetaStates = new KeyMetaStates(editor);
+    }
+
+    /**
+     * Get the {@link KeyMetaStates} instance.
+     *
+     * @return The {@link KeyMetaStates} instance.
+     */
+    @NonNull
+    public KeyMetaStates getKeyMetaStates() {
+        return mKeyMetaStates;
+    }
+
+    /**
+     * Called by editor in {@link CodeEditor#onKeyDown(int, KeyEvent)}.
+     *
+     * @param keyCode The key code.
+     * @param event   The key event.
+     * @return <code>true</code> if the event was handled, <code>false</code> otherwise.
+     */
+    public boolean onKeyDown(int keyCode, @NonNull KeyEvent event) {
+        mKeyMetaStates.onKeyDown(event);
+        final var editor = this.editor;
+        final var eventManager = editor.mEventManager;
+        final var connection = editor.mConnection;
+        final var editorCursor = editor.getCursor();
+        final var editorText = editor.getText();
+        final var completionWindow = editor.getComponent(EditorAutoCompletion.class);
+
+        var e = new EditorKeyEvent(editor, event);
+        if ((eventManager.dispatchEvent(e) & InterceptTarget.TARGET_EDITOR) != 0) {
+            return e.result(false);
+        }
+
+        boolean isShiftPressed = mKeyMetaStates.isShiftPressed();
+
+        // Currently, KeyBindingEvent is triggered only for (Shift | Ctrl | Alt) + alphabet keys
+        // Should we add support for more keys?
+        if ((isShiftPressed || event.isCtrlPressed() || event.isAltPressed())
+                && keyCode >= KeyEvent.KEYCODE_A && keyCode <= KeyEvent.KEYCODE_Z) {
+            final var keybindingEvent = new KeyBindingEvent(editor, event, keyCode, editor.canHandleKeyBinding(keyCode, event));
+            if ((eventManager.dispatchEvent(keybindingEvent) & InterceptTarget.TARGET_EDITOR) != 0) {
+                return keybindingEvent.result(false);
+            }
+        }
+
+        switch (keyCode) {
+            case KeyEvent.KEYCODE_DPAD_DOWN:
+            case KeyEvent.KEYCODE_DPAD_UP:
+            case KeyEvent.KEYCODE_DPAD_LEFT:
+            case KeyEvent.KEYCODE_DPAD_RIGHT:
+            case KeyEvent.KEYCODE_MOVE_HOME:
+            case KeyEvent.KEYCODE_MOVE_END:
+                if (isShiftPressed && (!editorCursor.isSelected())) {
+                    editor.mSelectionAnchor = editorCursor.left();
+                } else if (!isShiftPressed && editor.mSelectionAnchor != null) {
+                    editor.mSelectionAnchor = null;
+                }
+                mKeyMetaStates.adjust();
+        }
+
+        switch (keyCode) {
+            case KeyEvent.KEYCODE_BACK: {
+                if (editorCursor.isSelected()) {
+                    editor.setSelection(editorCursor.getLeftLine(), editorCursor.getLeftColumn());
+                    return e.result(true);
+                }
+                return e.result(false);
+            }
+            case KeyEvent.KEYCODE_DEL:
+                if (editor.isEditable()) {
+                    editor.deleteText();
+                    editor.notifyIMEExternalCursorChange();
+                }
+                return e.result(true);
+            case KeyEvent.KEYCODE_FORWARD_DEL: {
+                if (editor.isEditable()) {
+                    connection.deleteSurroundingText(0, 1);
+                    editor.notifyIMEExternalCursorChange();
+                }
+                return e.result(true);
+            }
+            case KeyEvent.KEYCODE_ENTER: {
+                if (editor.isEditable()) {
+                    final var editorLanguage = editor.getEditorLanguage();
+                    if (completionWindow.isShowing()) {
+                        completionWindow.select();
+                        return true;
+                    }
+                    NewlineHandler[] handlers = editorLanguage.getNewlineHandlers();
+                    if (handlers == null || editorCursor.isSelected()) {
+                        editor.commitText("\n", true);
+                    } else {
+                        ContentLine line = editorText.getLine(editorCursor.getLeftLine());
+                        int index = editorCursor.getLeftColumn();
+                        String beforeText = line.subSequence(0, index).toString();
+                        String afterText = line.subSequence(index, line.length()).toString();
+                        boolean consumed = false;
+                        for (NewlineHandler handler : handlers) {
+                            if (handler != null) {
+                                if (handler.matchesRequirement(beforeText, afterText)) {
+                                    try {
+                                        NewlineHandleResult result = handler.handleNewline(beforeText, afterText, editor.getTabWidth());
+                                        if (result != null) {
+                                            editor.commitText(result.text, false);
+                                            int delta = result.shiftLeft;
+                                            if (delta != 0) {
+                                                int newSel = Math.max(editorCursor.getLeft() - delta, 0);
+                                                CharPosition charPosition = editorCursor.getIndexer().getCharPosition(newSel);
+                                                editor.setSelection(charPosition.line, charPosition.column);
+                                            }
+                                            consumed = true;
+                                        } else {
+                                            continue;
+                                        }
+                                    } catch (Exception ex) {
+                                        Log.w(TAG, "Error occurred while calling Language's NewlineHandler", ex);
+                                    }
+                                    break;
+                                }
+                            }
+                        }
+                        if (!consumed) {
+                            editor.commitText("\n", true);
+                        }
+                    }
+                    editor.notifyIMEExternalCursorChange();
+                }
+                return e.result(true);
+            }
+            case KeyEvent.KEYCODE_DPAD_DOWN:
+                editor.moveSelectionDown();
+                return e.result(true);
+            case KeyEvent.KEYCODE_DPAD_UP:
+                editor.moveSelectionUp();
+                return e.result(true);
+            case KeyEvent.KEYCODE_DPAD_LEFT:
+                editor.moveSelectionLeft();
+                return e.result(true);
+            case KeyEvent.KEYCODE_DPAD_RIGHT:
+                editor.moveSelectionRight();
+                return e.result(true);
+            case KeyEvent.KEYCODE_MOVE_END:
+                editor.moveSelectionEnd();
+                return e.result(true);
+            case KeyEvent.KEYCODE_MOVE_HOME:
+                editor.moveSelectionHome();
+                return e.result(true);
+            case KeyEvent.KEYCODE_PAGE_DOWN:
+                editor.movePageDown();
+                return e.result(true);
+            case KeyEvent.KEYCODE_PAGE_UP:
+                editor.movePageUp();
+                return e.result(true);
+            case KeyEvent.KEYCODE_TAB:
+                if (editor.isEditable()) {
+                    if (completionWindow.isShowing()) {
+                        completionWindow.select();
+                    } else {
+                        editor.commitTab();
+                    }
+                }
+                return e.result(true);
+            case KeyEvent.KEYCODE_PASTE:
+                if (editor.isEditable()) {
+                    editor.pasteText();
+                }
+                return e.result(true);
+            case KeyEvent.KEYCODE_COPY:
+                editor.copyText();
+                return e.result(true);
+            case KeyEvent.KEYCODE_SPACE:
+                if (editor.isEditable()) {
+                    editor.commitText(" ");
+                    editor.notifyIMEExternalCursorChange();
+                }
+                return e.result(true);
+            case KeyEvent.KEYCODE_ESCAPE:
+                if (editorCursor.isSelected()) {
+                    // TODO Maybe we could add a flag in DirectAccessProps to change this behaviour
+                    //    So that user can select whether left or right cursor should be selected
+                    final var left = editorCursor.right();
+                    editor.setSelection(left.line, left.column, true);
+                }
+                return e.result(true);
+            default:
+                if (event.isCtrlPressed() && !event.isAltPressed()) {
+                    switch (keyCode) {
+                        case KeyEvent.KEYCODE_V:
+                            if (editor.isEditable()) {
+                                editor.pasteText();
+                            }
+                            return e.result(true);
+                        case KeyEvent.KEYCODE_C:
+                            editor.copyText();
+                            return e.result(true);
+                        case KeyEvent.KEYCODE_X:
+                            if (editor.isEditable()) {
+                                editor.cutText();
+                            } else {
+                                editor.copyText();
+                            }
+                            return e.result(true);
+                        case KeyEvent.KEYCODE_A:
+                            editor.selectAll();
+                            return e.result(true);
+                        case KeyEvent.KEYCODE_Z:
+                            if (editor.isEditable()) {
+                                editor.undo();
+                            }
+                            return e.result(true);
+                        case KeyEvent.KEYCODE_Y:
+                            if (editor.isEditable()) {
+                                editor.redo();
+                            }
+                            return e.result(true);
+                        case KeyEvent.KEYCODE_D:
+                            if (editor.isEditable()) {
+                                editor.duplicateLine();
+                            }
+                            return e.result(true);
+                    }
+                } else if (!event.isCtrlPressed() && !event.isAltPressed()) {
+                    if (event.isPrintingKey() && editor.isEditable()) {
+                        String text = new String(Character.toChars(event.getUnicodeChar(event.getMetaState())));
+                        SymbolPairMatch.Replacement replacement = null;
+                        if (text.length() == 1 && editor.getProps().symbolPairAutoCompletion) {
+                            replacement = editor.mLanguageSymbolPairs.getCompletion(text.charAt(0));
+                        }
+                        if (replacement == null || replacement == SymbolPairMatch.Replacement.NO_REPLACEMENT
+                                || (replacement.shouldNotDoReplace(editorText) && replacement.notHasAutoSurroundPair())) {
+                            editor.commitText(text);
+                            editor.notifyIMEExternalCursorChange();
+                        } else {
+                            String[] autoSurroundPair;
+                            if (editorCursor.isSelected() && (autoSurroundPair = replacement.getAutoSurroundPair()) != null) {
+                                editorText.beginBatchEdit();
+                                //insert left
+                                editorText.insert(editorCursor.getLeftLine(), editorCursor.getLeftColumn(), autoSurroundPair[0]);
+                                //insert right
+                                editorText.insert(editorCursor.getRightLine(), editorCursor.getRightColumn(), autoSurroundPair[1]);
+                                editorText.endBatchEdit();
+                                //cancel selected
+                                editor.setSelection(editorCursor.getLeftLine(), editorCursor.getLeftColumn() + autoSurroundPair[0].length() - 1);
+
+                                editor.notifyIMEExternalCursorChange();
+                            } else {
+                                editor.commitText(replacement.text);
+                                int delta = (replacement.text.length() - replacement.selection);
+                                if (delta != 0) {
+                                    int newSel = Math.max(editorCursor.getLeft() - delta, 0);
+                                    CharPosition charPosition = editorCursor.getIndexer().getCharPosition(newSel);
+                                    editor.setSelection(charPosition.line, charPosition.column);
+                                    editor.notifyIMEExternalCursorChange();
+                                }
+                            }
+
+                        }
+                    } else {
+                        return editor.onSuperKeyDown(keyCode, event);
+                    }
+                    return e.result(true);
+                }
+        }
+        return e.result(editor.onSuperKeyDown(keyCode, event));
+    }
+
+    /**
+     * Called by editor in {@link CodeEditor#onKeyUp(int, KeyEvent)}.
+     *
+     * @param keyCode The key code.
+     * @param event   The key event.
+     * @return <code>true</code> if the event was handled, <code>false</code> otherwise.
+     */
+    public boolean onKeyUp(int keyCode, @NonNull KeyEvent event) {
+        mKeyMetaStates.onKeyUp(event);
+
+        final var eventManager = this.editor.mEventManager;
+        final var cursor = this.editor.getCursor();
+
+        var e = new EditorKeyEvent(this.editor, event);
+        if ((eventManager.dispatchEvent(e) & InterceptTarget.TARGET_EDITOR) != 0) {
+            return e.result(false);
+        }
+        if (!mKeyMetaStates.isShiftPressed() && this.editor.mSelectionAnchor != null && !cursor.isSelected()) {
+            this.editor.mSelectionAnchor = null;
+            return e.result(true);
+        }
+        return e.result(this.editor.onSuperKeyUp(keyCode, event));
+    }
+
+    /**
+     * Called by editor in {@link CodeEditor#onKeyMultiple(int, int, KeyEvent)}.
+     *
+     * @param keyCode     The key code.
+     * @param repeatCount The repeat count.
+     * @param event       The key event.
+     * @return <code>true</code> if the event was handled, <code>false</code> otherwise.
+     */
+    public boolean onKeyMultiple(int keyCode, int repeatCount, @NonNull KeyEvent event) {
+        var e = new EditorKeyEvent(this.editor, event);
+        if ((this.editor.mEventManager.dispatchEvent(e) & InterceptTarget.TARGET_EDITOR) != 0) {
+            return e.result(false);
+        }
+        return e.result(this.editor.onSuperKeyMultiple(keyCode, repeatCount, event));
+    }
+}

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/EditorTouchEventHandler.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/EditorTouchEventHandler.java
@@ -509,32 +509,6 @@ public final class EditorTouchEventHandler implements GestureDetector.OnGestureL
         return true;
     }
 
-    private void selectWord(int line, int column) {
-        // Find word edges
-        int startLine = line, endLine = line;
-        var lineObj = mEditor.getText().getLine(line);
-        long edges = ICUUtils.getWordEdges(lineObj, column);
-        int startColumn = IntPair.getFirst(edges);
-        int endColumn = IntPair.getSecond(edges);
-        if (startColumn == endColumn) {
-            if (startColumn > 0) {
-                startColumn--;
-            } else if (endColumn < lineObj.length()) {
-                endColumn++;
-            } else {
-                if (line > 0) {
-                    int lastColumn = mEditor.getText().getColumnCount(line - 1);
-                    startLine = line - 1;
-                    startColumn = lastColumn;
-                } else if (line < mEditor.getLineCount() - 1) {
-                    endLine = line + 1;
-                    endColumn = 0;
-                }
-            }
-        }
-        mEditor.setSelectionRegion(startLine, startColumn, endLine, endColumn, SelectionChangeEvent.CAUSE_LONG_PRESS);
-    }
-
     @Override
     public void onLongPress(MotionEvent e) {
         long res = mEditor.getPointPositionOnScreen(e.getX(), e.getY());
@@ -547,7 +521,7 @@ public final class EditorTouchEventHandler implements GestureDetector.OnGestureL
             return;
         }
         mEditor.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS);
-        selectWord(line, column);
+        mEditor.selectWord(line, column);
     }
 
     @Override
@@ -704,7 +678,7 @@ public final class EditorTouchEventHandler implements GestureDetector.OnGestureL
         if (mEditor.getCursor().isSelected() || e.getPointerCount() != 1) {
             return true;
         }
-        selectWord(line, column);
+        mEditor.selectWord(line, column);
         return true;
     }
 

--- a/language-textmate/src/main/java/io/github/rosemoe/sora/textmate/core/internal/parser/xml/XMLPListParser.java
+++ b/language-textmate/src/main/java/io/github/rosemoe/sora/textmate/core/internal/parser/xml/XMLPListParser.java
@@ -34,7 +34,6 @@ public class XMLPListParser<T> {
     public T parse(InputStream contents) throws Exception {
         SAXParserFactory spf = SAXParserFactory.newInstance();
         spf.setNamespaceAware(true);
-        spf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
         SAXParser saxParser = spf.newSAXParser();
         XMLReader xmlReader = saxParser.getXMLReader();
         xmlReader.setEntityResolver((arg0, arg1) -> new InputSource(new ByteArrayInputStream("<?xml version='1.0' encoding='UTF-8'?>".getBytes())));


### PR DESCRIPTION
This PR adds `KeyBindingEvent` and support for handling a few more keybidings.

## The `KeyBindingEvent`
This event is dispatched to receivers when users press some special keys at the same time. For example, this event will be dispatched if a user presses `Ctrl + any alphabet key`.

## New keybindings
- `Ctrl + D`: If content is selected, duplicates the selected content else duplicates the current line.
- `Ctrl + W`: Selects the word at the left selection handle.
- `Shift + Enter`: Start a new line.
- `Ctrl + Enter`: Split line. If content is selected, deletes the selected content then splits the line.
- `Ctrl + Alt + Enter` : Start a new line before current line.
- `Ctrl + Shift + J`: Join current line and next line.

## Updated keybindings
- `Ctrl + X`: If no content is selected, cuts the current line. Else, performs the usual cut operation.
- `Ctrl + C`: If no content is selected, selects and copies the current line. Else, performs the usual copy operation.

## Other changes
- Fixed a bug which caused the TextMate's `ThemeReader` to crash with `SAXNotRecognizedException`. This bug was introduced in #190 (the changes were surely not tested by the PR author). [Here](https://cs.android.com/android/platform/superproject/+/master:libcore/luni/src/main/java/org/apache/harmony/xml/parsers/SAXParserFactoryImpl.java;drc=d43b9ef11a1095967a3396b246639b563e1a4128;l=92) is why the exception is thrown when [`XMLConstants.FEATURE_SECURE_PROCESSING`](https://cs.android.com/android/platform/superproject/+/master:libcore/luni/src/main/java/javax/xml/XMLConstants.java;drc=f33eae7e84eb6d3b0f4e86b59605bb3de73009f3;l=178) is set to `SAXParserFactory`. I don't know if the XXE vulnerability exists in Android OS or not. If it does, we need to find a way other than setting the 'secure processing' feature.
- The logic for handling key events has been moved to class `EditorKeyEventHandler`.
- When content is selected, pressing the `Esc` button on keyboard now exits the selection  mode.
- Added a switch to enable/disable the use of ICU library while computing word edges.

## Additional info
The above key combinations are taken from Android Studio.

I had to change the AGP version of sora-editor to `v7.3.0-beat03` in order to build the project because Android Studio Dolphin does not support `v7.4.0-alpha03`. You should probably use stable versions of the Android Gradle Plugin. Anyways, I reverted the AGP version to `7.4.0-alpha03`.

<details>
  <summary>Here is the stacktrace of the crash caused by the FEATURE_SECURE_PROCESSING</summary>

```
FATAL EXCEPTION: main
    Process: io.github.rosemoe.sora.app, PID: 18562
    java.lang.RuntimeException: Unable to start activity ComponentInfo{io.github.rosemoe.sora.app/io.github.rosemoe.sora.app.MainActivity}: org.xml.sax.SAXNotRecognizedException: http://javax.xml.XMLConstants/feature/secure-processing
   	at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:3729)
   	at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:3896)
   	at android.app.servertransaction.LaunchActivityItem.execute(LaunchActivityItem.java:85)
   	at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:140)
   	at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:100)
   	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2326)
   	at android.os.Handler.dispatchMessage(Handler.java:106)
   	at android.os.Looper.loop(Looper.java:263)
   	at android.app.ActivityThread.main(ActivityThread.java:8296)
   	at java.lang.reflect.Method.invoke(Native Method)
   	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:612)
   	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1006)
   Caused by: org.xml.sax.SAXNotRecognizedException: http://javax.xml.XMLConstants/feature/secure-processing
   	at org.apache.harmony.xml.parsers.SAXParserFactoryImpl.setFeature(SAXParserFactoryImpl.java:93)
   	at io.github.rosemoe.sora.textmate.core.internal.parser.xml.XMLPListParser.parse(XMLPListParser.java:37)
   	at io.github.rosemoe.sora.textmate.core.internal.theme.reader.ThemeReader$1.parse(ThemeReader.java:37)
   	at io.github.rosemoe.sora.textmate.core.internal.theme.reader.SyncThemeReader.load(SyncThemeReader.java:34)
   	at io.github.rosemoe.sora.textmate.core.internal.theme.reader.ThemeReader.readThemeSync(ThemeReader.java:58)
   	at io.github.rosemoe.sora.app.MainActivity.onCreate(MainActivity.kt:135)
   	at android.app.Activity.performCreate(Activity.java:8153)
   	at android.app.Activity.performCreate(Activity.java:8137)
   	at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1310)
   	at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:3698)
   	at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:3896) 
   	at android.app.servertransaction.LaunchActivityItem.execute(LaunchActivityItem.java:85) 
   	at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:140) 
   	at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:100) 
   	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2326) 
   	at android.os.Handler.dispatchMessage(Handler.java:106) 
   	at android.os.Looper.loop(Looper.java:263) 
   	at android.app.ActivityThread.main(ActivityThread.java:8296) 
   	at java.lang.reflect.Method.invoke(Native Method) 
   	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:612) 
```
</details>