### PR TITLE
Add code snippet support in code completion for `editor-lsp`

### DIFF
--- a/app/src/main/java/io/github/rosemoe/sora/app/LspTestActivity.kt
+++ b/app/src/main/java/io/github/rosemoe/sora/app/LspTestActivity.kt
@@ -202,7 +202,12 @@ class LspTestActivity : AppCompatActivity() {
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         val id = item.itemId
         if (id == R.id.code_format) {
-            editor.formatCodeAsync()
+            val cursor = editor.text.cursor
+            if (cursor.isSelected) {
+                editor.formatCodeAsync(cursor.left(), cursor.right())
+            } else {
+                editor.formatCodeAsync()
+            }
         }
         return super.onOptionsItemSelected(item)
     }

--- a/editor-lsp/README.md
+++ b/editor-lsp/README.md
@@ -10,8 +10,9 @@ languages, such as auto-completion, formatting, etc.
 
 ## Features(already available)
 
-1. `textDocument/rangeFormatting`
-2. `textDocument/diagnostic`
+1.`textDocument/formatting`
+2.`textDocument/rangeFormatting`
+3.`textDocument/diagnostic`
 
 ## How to connect to the language server
 

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/client/DefaultLanguageClient.java
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/client/DefaultLanguageClient.java
@@ -45,6 +45,7 @@ import java.util.concurrent.CompletableFuture;
 
 import io.github.rosemoe.sora.lsp.editor.LspEditor;
 import io.github.rosemoe.sora.lsp.editor.LspEditorManager;
+import io.github.rosemoe.sora.lsp.utils.URIUtils;
 
 public class DefaultLanguageClient implements LanguageClient {
 
@@ -58,11 +59,10 @@ public class DefaultLanguageClient implements LanguageClient {
 
     @Override
     public CompletableFuture<ApplyWorkspaceEditResponse> applyEdit(ApplyWorkspaceEditParams params) {
-       /* boolean response = WorkspaceEditHandler.applyEdit(params.getEdit(), "LSP edits");*/
+        /* boolean response = WorkspaceEditHandler.applyEdit(params.getEdit(), "LSP edits");*/
         //FIXME: Support it?
         return CompletableFuture.supplyAsync(() -> new ApplyWorkspaceEditResponse(false));
     }
-
 
 
     @Override
@@ -72,43 +72,27 @@ public class DefaultLanguageClient implements LanguageClient {
 
     @Override
     public CompletableFuture<List<WorkspaceFolder>> workspaceFolders() {
-        return LanguageClient.super.workspaceFolders();
+        var workSpaceFolder = new WorkspaceFolder();
+        workSpaceFolder.setUri(URIUtils.fileToURI(context.getProjectPath()).toString());
+        // Always return the current project path
+        return CompletableFuture.completedFuture(List.of(workSpaceFolder));
     }
 
     @Override
     public CompletableFuture<Void> registerCapability(RegistrationParams params) {
-        /*return CompletableFuture.runAsync(() -> params.getRegistrations().forEach(r -> {
-            String id = r.getId();
-            Optional<DynamicRegistrationMethods> method = DynamicRegistrationMethods.forName(r.getMethod());
-            method.ifPresent(dynamicRegistrationMethods -> registrations.put(id, dynamicRegistrationMethods));
-
-        }));*/
+        //Not prepared to support this feature
         return CompletableFuture.completedFuture(null);
     }
 
     @Override
     public CompletableFuture<Void> unregisterCapability(UnregistrationParams params) {
-       /* return CompletableFuture.runAsync(() -> params.getUnregisterations().forEach((Unregistration r) -> {
-            String id = r.getId();
-            Optional<DynamicRegistrationMethods> method = DynamicRegistrationMethods.forName(r.getMethod());
-            if (registrations.containsKey(id)) {
-                registrations.remove(id);
-            } else {
-                Map<DynamicRegistrationMethods, String> inverted = new HashMap<>();
-                for (Map.Entry<String, DynamicRegistrationMethods> entry : registrations.entrySet()) {
-                    inverted.put(entry.getValue(), entry.getKey());
-                }
-                if (method.isPresent() && inverted.containsKey(method.get())) {
-                    registrations.remove(inverted.get(method.get()));
-                }
-            }
-        }));*/
+        // Not prepared to support this feature
         return CompletableFuture.completedFuture(null);
     }
 
     @Override
     public void telemetryEvent(Object o) {
-        Log.i(TAG, "telemetryEvent: "+o.toString());
+        Log.i(TAG, "telemetryEvent: " + o.toString());
     }
 
     @Override

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/client/languageserver/requestmanager/DefaultRequestManager.java
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/client/languageserver/requestmanager/DefaultRequestManager.java
@@ -480,7 +480,7 @@ public class DefaultRequestManager implements RequestManager {
     public CompletableFuture<List<? extends DocumentHighlight>> documentHighlight(DocumentHighlightParams params) {
         if (checkStatus()) {
             try {
-                return (serverCapabilities.getDocumentHighlightProvider().getRight() != null) ? textDocumentService.documentHighlight(params) : null;
+                return (serverCapabilities.getDocumentHighlightProvider() != null) ? textDocumentService.documentHighlight(params) : null;
             } catch (Exception e) {
                 crashed(e);
                 return null;
@@ -493,7 +493,7 @@ public class DefaultRequestManager implements RequestManager {
     public CompletableFuture<List<Either<SymbolInformation, DocumentSymbol>>> documentSymbol(DocumentSymbolParams params) {
         if (checkStatus()) {
             try {
-                return (serverCapabilities.getDocumentSymbolProvider().getRight() != null) ? textDocumentService.documentSymbol(params) : null;
+                return (serverCapabilities.getDocumentSymbolProvider() != null) ? textDocumentService.documentSymbol(params) : null;
             } catch (Exception e) {
                 crashed(e);
                 return null;
@@ -506,7 +506,7 @@ public class DefaultRequestManager implements RequestManager {
     public CompletableFuture<List<? extends TextEdit>> formatting(DocumentFormattingParams params) {
         if (checkStatus()) {
             try {
-                return (serverCapabilities.getDocumentFormattingProvider().getRight() != null) ? textDocumentService.formatting(params) : null;
+                return (serverCapabilities.getDocumentFormattingProvider() != null) ? textDocumentService.formatting(params) : null;
             } catch (Exception e) {
                 crashed(e);
                 return null;

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/client/languageserver/wrapper/LanguageServerWrapper.java
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/client/languageserver/wrapper/LanguageServerWrapper.java
@@ -75,6 +75,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -97,6 +98,7 @@ import io.github.rosemoe.sora.lsp.editor.LspEditor;
 import io.github.rosemoe.sora.lsp.editor.LspEditorManager;
 import io.github.rosemoe.sora.lsp.utils.LSPException;
 import io.github.rosemoe.sora.lsp.utils.URIUtils;
+import io.github.rosemoe.sora.util.MyCharacter;
 
 /**
  * The implementation of a LanguageServerWrapper (specific to a serverDefinition and a project)
@@ -398,17 +400,18 @@ public class LanguageServerWrapper {
      */
     public void connect(LspEditor editor) {
 
-        String uri = editor.getCurrentFileUri();
+        var uri = editor.getCurrentFileUri();
         if (connectedEditors.contains(editor)) {
             return;
         }
-        Pair<String, String> key = new Pair<>(uri, editor.getProjectPath());
+        var key = new Pair<>(uri, editor.getProjectPath());
 
         uriToLanguageServerWrapper.put(key, this);
 
         start();
+
         if (initializeFuture != null) {
-            ServerCapabilities capabilities = getServerCapabilities();
+            var capabilities = getServerCapabilities();
             if (capabilities == null) {
                 Log.w(TAG, "Capabilities are null for " + serverDefinition);
                 return;
@@ -424,10 +427,17 @@ public class LanguageServerWrapper {
                         synchronized (toConnect) {
                             toConnect.remove(editor);
                         }
-                        TextDocumentSyncKind textDocumentSyncKind = syncOptions.isLeft() ? syncOptions.getLeft() : syncOptions.getRight().getChange();
+                        var textDocumentSyncKind = syncOptions.isLeft() ? syncOptions.getLeft() : syncOptions.getRight().getChange();
                         textDocumentSyncKind = textDocumentSyncKind == null ? TextDocumentSyncKind.Full : textDocumentSyncKind;
 
                         editor.setSyncOptions(textDocumentSyncKind);
+
+
+                        var completionTriggers = (capabilities.getCompletionProvider() != null
+                                && capabilities.getCompletionProvider().getTriggerCharacters() != null) ?
+                                capabilities.getCompletionProvider().getTriggerCharacters() : new ArrayList<String>();
+
+                        editor.setCompletionTriggers(completionTriggers);
 
                         editor.installFeatures();
 

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/editor/LspEditorManager.java
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/editor/LspEditorManager.java
@@ -40,12 +40,12 @@ public class LspEditorManager {
         this.currentProjectPath = currentProjectPath;
     }
 
-    private Map<String, LspEditor> editors = new HashMap<>();
+    private final Map<String, LspEditor> editors = new HashMap<>();
 
-    private static Map<String, LspEditorManager> managers = new HashMap<>();
+    private static final Map<String, LspEditorManager> managers = new HashMap<>();
 
     public static LspEditorManager getOrCreateEditorManager(String projectPath) {
-        LspEditorManager manager = managers.get(projectPath);
+        var manager = managers.get(projectPath);
         if (manager == null) {
             manager = new LspEditorManager(projectPath);
             managers.put(projectPath, manager);
@@ -90,6 +90,8 @@ public class LspEditorManager {
 
         // Maybe the user should be allowed to call the method themselves
         LspUtils.clearVersions();
+
+
 
     }
 

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/editor/completion/CompletionItemProvider.java
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/editor/completion/CompletionItemProvider.java
@@ -21,33 +21,13 @@
  *     Please contact Rosemoe by email 2073412493@qq.com if you need
  *     additional information or have any questions
  */
-package io.github.rosemoe.sora.lsp.requests;
+package io.github.rosemoe.sora.lsp.editor.completion;
 
+import io.github.rosemoe.sora.lang.completion.CompletionItem;
+import io.github.rosemoe.sora.lsp.operations.document.ApplyEditsFeature;
 
-import java.util.Arrays;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+public interface CompletionItemProvider<T extends CompletionItem> {
 
-/**
- * An object containing the Timeout for the various requests
- */
-public class Timeout {
+    T createCompletionItem(org.eclipse.lsp4j.CompletionItem completionItem, ApplyEditsFeature applyEditsFeature, int prefixLength);
 
-    private static final Map<Timeouts, Integer> timeouts = new ConcurrentHashMap<>();
-
-    static {
-        Arrays.stream(Timeouts.values()).forEach(t -> timeouts.put(t, t.getDefaultTimeout()));
-    }
-
-    public static int getTimeout(Timeouts type) {
-        return timeouts.get(type);
-    }
-
-    public static Map<Timeouts, Integer> getTimeouts() {
-        return timeouts;
-    }
-
-    public static void setTimeouts(Map<Timeouts, Integer> loaded) {
-        loaded.forEach(timeouts::replace);
-    }
 }

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/editor/completion/LspCompletionItem.java
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/editor/completion/LspCompletionItem.java
@@ -23,74 +23,195 @@
  */
 package io.github.rosemoe.sora.lsp.editor.completion;
 
+import android.util.Log;
+import android.util.Pair;
+
 import org.eclipse.lsp4j.InsertTextFormat;
 import org.eclipse.lsp4j.TextEdit;
 
-import io.github.rosemoe.sora.lang.completion.CompletionHelper;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import io.github.rosemoe.sora.lang.completion.CompletionItem;
+import io.github.rosemoe.sora.lsp.operations.document.ApplyEditsFeature;
+import io.github.rosemoe.sora.lsp.utils.LspUtils;
 import io.github.rosemoe.sora.text.Content;
-import io.github.rosemoe.sora.util.IntPair;
-import io.github.rosemoe.sora.util.MyCharacter;
 import io.github.rosemoe.sora.widget.CodeEditor;
 
 public class LspCompletionItem extends CompletionItem implements Comparable<LspCompletionItem> {
 
-
-    private final org.eclipse.lsp4j.CompletionItem commitItem;
+    private org.eclipse.lsp4j.CompletionItem commitItem;
     private final int prefixLength;
 
+    private ApplyEditsFeature applyEditsFeature;
 
-    public LspCompletionItem(org.eclipse.lsp4j.CompletionItem completionItem, int prefixLength) {
+    private static final String SNIPPET_PLACEHOLDER_REGEX_1 = "\\$\\{\\d+:?([^{^}]*)\\}";
+
+    private static final String SNIPPET_PLACEHOLDER_REGEX_2 = "\\$\\d+";
+
+    public LspCompletionItem(org.eclipse.lsp4j.CompletionItem completionItem, ApplyEditsFeature applyEditsFeature, int prefixLength) {
         super(completionItem.getLabel(), completionItem.getDetail());
         this.commitItem = completionItem;
         this.prefixLength = prefixLength;
+        this.applyEditsFeature = applyEditsFeature;
     }
 
     @Override
     public void performCompletion(CodeEditor editor, Content text, int line, int column) {
 
-        var insertText = commitItem.getInsertText();
+        var textEdit = new TextEdit();
 
+        var cursorPosition = LspUtils.createPosition(line, column);
 
-        if (insertText != null) {
-            //TODO: Support InsertTextFormat.Snippet
+        textEdit.setRange(LspUtils.createRange(LspUtils.createPosition(line, column - prefixLength), LspUtils.createPosition(line, column)));
 
-            //always insert text
-            text.replace(line, column - prefixLength, line, column, insertText);
-            return;
+        if (commitItem.getInsertText() != null) {
+            textEdit.setNewText(commitItem.getInsertText());
         }
 
-        if (commitItem.getTextEdit() != null) {
+
+
+
+        if (commitItem.getTextEdit() != null && commitItem.getTextEdit().isLeft()) {
 
             //TODO: support InsertReplaceEdit
-
-            if (commitItem.getTextEdit().isLeft()) {
-
-                var textEdit = commitItem.getTextEdit().getLeft();
-                String commitText = textEdit.getNewText();
-                text.replace(textEdit.getRange().getStart().getLine(), textEdit.getRange().getStart().getCharacter(),
-                        textEdit.getRange().getEnd().getLine(), textEdit.getRange().getEnd().getCharacter(),
-                        commitText);
-            }
-
-            return;
+            textEdit = commitItem.getTextEdit().getLeft();
 
         }
 
-        insertText = commitItem.getLabel();
+        if (textEdit.getNewText() == null && commitItem.getLabel() != null) {
+            textEdit.setNewText(commitItem.getLabel());
+        }
 
 
-        text.replace(line, column - prefixLength, line, column, insertText);
+        { // workaround https://github.com/Microsoft/vscode/issues/17036
+            var start = textEdit.getRange().getStart();
+            var end = textEdit.getRange().getEnd();
+            if (start.getLine() > end.getLine() || (start.getLine() == end.getLine() && start.getCharacter() > end.getCharacter())) {
+                textEdit.getRange().setEnd(start);
+                textEdit.getRange().setStart(end);
+            }
+        }
+
+        { // allow completion items to be wrong with a too wide range
+            var documentEnd = LspUtils.createPosition(
+                    text.getLineCount() - 1, text.getColumnCount(line - 1)
+            );
+            var textEditEnd = textEdit.getRange().getEnd();
+            if (documentEnd.getLine() < textEditEnd.getLine()
+                    || (documentEnd.getLine() == textEditEnd.getLine() && documentEnd.getCharacter() < textEditEnd.getCharacter())) {
+                textEdit.getRange().setEnd(documentEnd);
+            }
+        }
+
+
+        SnippetVariable firstSnippetVariable = null;
+
+        if (commitItem.getInsertTextFormat() == InsertTextFormat.Snippet) {
+            try {
+                var variables = new ArrayList<SnippetVariable>();
+                // Extracts variables using placeholder REGEX pattern.
+                var varMatcher = Pattern.compile(SNIPPET_PLACEHOLDER_REGEX_1).matcher(textEdit.getNewText());
+                while (varMatcher.find()) {
+                    variables.add(new SnippetVariable(varMatcher.group(), varMatcher.start(), varMatcher.end()));
+                }
+
+                varMatcher = Pattern.compile(SNIPPET_PLACEHOLDER_REGEX_2).matcher(textEdit.getNewText());
+
+                while (varMatcher.find()) {
+                    variables.add(new SnippetVariable(varMatcher.group(), varMatcher.start(), varMatcher.end()));
+                }
+
+                variables.sort(Comparator.comparingInt(o -> o.startIndex));
+
+                firstSnippetVariable = variables.get(0);
+
+                final String[] finalInsertText = {textEdit.getNewText()};
+                variables.forEach(var -> finalInsertText[0] = finalInsertText[0].replace(var.snippetText, "$"));
+
+                String[] splitInsertText = finalInsertText[0].split("\\$");
+
+
+                finalInsertText[0] = String.join("", splitInsertText);
+
+                textEdit.setNewText(finalInsertText[0]);
+
+
+            } catch (Exception e) {
+                Log.e("aaa", "bbb", e);
+                throw e;
+            }
+
+        }
+
+        applyEditsFeature.execute(new Pair<>(List.of(textEdit), text));
+
+
+        if (firstSnippetVariable != null) {
+            var startPosition = textEdit.getRange().getStart();
+            var targetIndex = text.getCharIndex(startPosition.getLine(), startPosition.getCharacter());
+
+            targetIndex += firstSnippetVariable.startIndex;
+
+            cursorPosition = LspUtils.createPosition(text.getIndexer().getCharPosition(targetIndex));
+
+        }
+
+
+        text.getCursor().set(cursorPosition.getLine(), cursorPosition.getCharacter());
+
+        if (commitItem.getAdditionalTextEdits() != null) {
+            applyEditsFeature.execute(new Pair<>(commitItem.getAdditionalTextEdits(), text));
+        }
+
 
     }
-
 
     @Override
     public int compareTo(LspCompletionItem completionItem) {
         if (commitItem.getSortText() != null && completionItem.commitItem.getSortText() != null) {
             return commitItem.getSortText().compareTo(completionItem.commitItem.getSortText());
         }
+
         return commitItem.getLabel().compareTo(completionItem.commitItem.getLabel());
     }
+
+    static class SnippetVariable {
+        String snippetText;
+        int startIndex;
+        int endIndex;
+        String variableValue;
+
+
+        SnippetVariable(String text, int start, int end) {
+            this.snippetText = text;
+            this.startIndex = start;
+            this.endIndex = end;
+            this.variableValue = getVariableValue(text);
+        }
+
+        private String getVariableValue(String lspVarSnippet) {
+            if (lspVarSnippet.contains(":")) {
+                return lspVarSnippet.substring(lspVarSnippet.indexOf(':') + 1, lspVarSnippet.lastIndexOf('}'));
+            }
+            return " ";
+        }
+
+        @Override
+        public String toString() {
+            return "SnippetVariable{" +
+                    "snippetText='" + snippetText + '\'' +
+                    ", startIndex=" + startIndex +
+                    ", endIndex=" + endIndex +
+                    ", variableValue='" + variableValue + '\'' +
+                    '}';
+        }
+    }
+
 }
 

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/editor/event/LspEditorContentChangeEventReceiver.java
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/editor/event/LspEditorContentChangeEventReceiver.java
@@ -38,13 +38,9 @@ public class LspEditorContentChangeEventReceiver implements EventReceiver<Conten
         this.editor = editor;
     }
 
-
     @Override
     public void onReceive(ContentChangeEvent event, Unsubscribe unsubscribe) {
-        DocumentChangeFeature feature = editor.useFeature(DocumentChangeFeature.class);
-        if (feature == null) {
-            return;
-        }
-        feature.execute(event);
+        editor.safeUseFeature(DocumentChangeFeature.class)
+                .ifPresent(documentChangeFeature -> documentChangeFeature.execute(event));
     }
 }

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/editor/format/LspFormatter.java
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/editor/format/LspFormatter.java
@@ -30,7 +30,8 @@ import androidx.annotation.Nullable;
 
 import io.github.rosemoe.sora.lang.format.AsyncFormatter;
 import io.github.rosemoe.sora.lsp.editor.LspLanguage;
-import io.github.rosemoe.sora.lsp.operations.format.FormattingFeature;
+import io.github.rosemoe.sora.lsp.operations.format.FullFormattingFeature;
+import io.github.rosemoe.sora.lsp.operations.format.RangeFormattingFeature;
 import io.github.rosemoe.sora.text.Content;
 import io.github.rosemoe.sora.text.TextRange;
 
@@ -42,27 +43,19 @@ public class LspFormatter extends AsyncFormatter {
         this.language = currentLanguage;
     }
 
-
     @Nullable
     @Override
     public TextRange formatAsync(@NonNull Content text, @NonNull TextRange cursorRange) {
-        var indexer = text.getIndexer();
-        var charPositionOfStart = indexer.getCharPosition(0);
-        var charPositionOfEnd = indexer.getCharPosition(
-                text.getLineCount() - 1,
-                text.getColumnCount(text.getLineCount() - 1) - 1
-
-        );
-        language.getEditor()
-                .useFeature(FormattingFeature.class)
-                .execute(new Pair<>(text, new TextRange(charPositionOfStart, charPositionOfEnd)));
+        language.getEditor().safeUseFeature(FullFormattingFeature.class)
+                .ifPresent(fullFormattingFeature -> fullFormattingFeature.execute(text));
         return null;
     }
 
     @Nullable
     @Override
     public TextRange formatRegionAsync(@NonNull Content text, @NonNull TextRange rangeToFormat, @NonNull TextRange cursorRange) {
-        language.getEditor().useFeature(FormattingFeature.class).execute(new Pair<>(text, cursorRange));
+        language.getEditor().safeUseFeature(RangeFormattingFeature.class)
+                .ifPresent(rangeFormattingFeature -> rangeFormattingFeature.execute(new Pair<>(text, cursorRange)));
         return null;
     }
 

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/operations/Feature.java
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/operations/Feature.java
@@ -25,7 +25,7 @@ package io.github.rosemoe.sora.lsp.operations;
 
 import io.github.rosemoe.sora.lsp.editor.LspEditor;
 
-public interface Feature<T,R> {
+public interface Feature<T, R> {
 
     void install(LspEditor editor);
 

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/operations/diagnostics/PublishDiagnosticsFeature.java
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/operations/diagnostics/PublishDiagnosticsFeature.java
@@ -41,7 +41,6 @@ import io.github.rosemoe.sora.widget.CodeEditor;
 
 public class PublishDiagnosticsFeature implements Feature<PublishDiagnosticsParams, Void> {
 
-
     private LspEditor editor;
 
 
@@ -57,7 +56,7 @@ public class PublishDiagnosticsFeature implements Feature<PublishDiagnosticsPara
     }
 
     private int getIndexForPosition(Position position) {
-        CodeEditor currentEditor = editor.getEditor();
+        var currentEditor = editor.getEditor();
 
         if (currentEditor == null) {
             return 0;
@@ -70,18 +69,17 @@ public class PublishDiagnosticsFeature implements Feature<PublishDiagnosticsPara
     @Override
     public Void execute(PublishDiagnosticsParams data) {
 
-        CodeEditor currentEditor = editor.getEditor();
+        var currentEditor = editor.getEditor();
 
         if (currentEditor == null) {
             return null;
         }
 
-        DiagnosticsContainer diagnosticsContainer = currentEditor.getDiagnostics() != null ? currentEditor.getDiagnostics() : new DiagnosticsContainer();
+        var diagnosticsContainer = currentEditor.getDiagnostics() != null ? currentEditor.getDiagnostics() : new DiagnosticsContainer();
 
         diagnosticsContainer.reset();
 
-        AtomicInteger id = new AtomicInteger();
-
+        var id = new AtomicInteger();
 
         List<DiagnosticRegion> diagnosticRegionList = data.getDiagnostics().stream().map(it -> {
             Log.w("diagnostic message", "diagnostic: " + it.getMessage());

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/operations/document/DocumentChangeFeature.java
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/operations/document/DocumentChangeFeature.java
@@ -30,6 +30,7 @@ import org.eclipse.lsp4j.TextDocumentContentChangeEvent;
 import org.eclipse.lsp4j.TextDocumentSyncKind;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ForkJoinPool;
 
@@ -61,15 +62,14 @@ public class DocumentChangeFeature implements Feature<ContentChangeEvent, Void> 
     }
 
 
-    @Nullable
     public CompletableFuture<Void> getFuture() {
-        return future;
+        return Optional.ofNullable(future).orElse(CompletableFuture.completedFuture(null));
     }
 
     @Override
     public Void execute(ContentChangeEvent data) {
 
-        DidChangeTextDocumentParams params = createDidChangeTextDocumentParams(data);
+        var params = createDidChangeTextDocumentParams(data);
 
         editor.getRequestManagerOfOptional().ifPresent(requestManager -> {
             ForkJoinPool.commonPool().execute(() -> {
@@ -88,15 +88,15 @@ public class DocumentChangeFeature implements Feature<ContentChangeEvent, Void> 
     }
 
     private List<TextDocumentContentChangeEvent> createIncrementTextDocumentContentChangeEvent(ContentChangeEvent data) {
-        String text = data.getChangedText().toString();
+        var text = data.getChangedText().toString();
         return List.of(LspUtils.createTextDocumentContentChangeEvent(LspUtils.createRange(data.getChangeStart(), data.getChangeEnd()), data.getAction() == ContentChangeEvent.ACTION_DELETE ? text.length() : 0, data.getAction() == ContentChangeEvent.ACTION_DELETE ? "" : text));
     }
 
 
     private DidChangeTextDocumentParams createDidChangeTextDocumentParams(ContentChangeEvent data) {
-        TextDocumentSyncKind kind = editor.getSyncOptions();
+        var kind = editor.getSyncOptions();
 
-        boolean isFullSync = kind == TextDocumentSyncKind.None || kind == TextDocumentSyncKind.Full;
+        var isFullSync = kind == TextDocumentSyncKind.None || kind == TextDocumentSyncKind.Full;
 
         return LspUtils.createDidChangeTextDocumentParams(editor.getCurrentFileUri(), isFullSync ? createFullTextDocumentContentChangeEvent() : createIncrementTextDocumentContentChangeEvent(data));
     }

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/operations/document/DocumentCloseFeature.java
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/operations/document/DocumentCloseFeature.java
@@ -55,12 +55,7 @@ public class DocumentCloseFeature implements Feature<Void, CompletableFuture<Voi
     @Override
     public CompletableFuture<Void> execute(Void data) {
 
-        editor.getRequestManagerOfOptional()
-                .ifPresent(requestManager -> future = CompletableFuture.runAsync(() ->
-                        requestManager.didClose(
-                                LspUtils.createDidCloseTextDocumentParams(
-                                        editor.getCurrentFileUri()
-                                ))));
+        editor.getRequestManagerOfOptional().ifPresent(requestManager -> future = CompletableFuture.runAsync(() -> requestManager.didClose(LspUtils.createDidCloseTextDocumentParams(editor.getCurrentFileUri()))));
 
         ForkJoinPool.commonPool().execute(future::join);
 

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/operations/document/DocumentOpenFeature.java
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/operations/document/DocumentOpenFeature.java
@@ -54,11 +54,7 @@ public class DocumentOpenFeature implements Feature<Void, Void> {
     @Override
     public Void execute(Void data) {
 
-        editor.getRequestManagerOfOptional()
-                .ifPresent(requestManager -> future = CompletableFuture.runAsync(() ->
-                        requestManager.didOpen(LspUtils.createDidOpenTextDocumentParams(
-                                editor.getCurrentFileUri(),
-                                editor.getFileExt(), editor.getEditorContent()))));
+        editor.getRequestManagerOfOptional().ifPresent(requestManager -> future = CompletableFuture.runAsync(() -> requestManager.didOpen(LspUtils.createDidOpenTextDocumentParams(editor.getCurrentFileUri(), editor.getFileExt(), editor.getEditorContent()))));
 
 
         ForkJoinPool.commonPool().execute(future::join);

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/operations/document/DocumentSaveFeature.java
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/operations/document/DocumentSaveFeature.java
@@ -54,12 +54,7 @@ public class DocumentSaveFeature implements Feature<Void, Void> {
     @Override
     public Void execute(Void data) {
 
-        editor.getRequestManagerOfOptional()
-                .ifPresent(requestManager -> future = CompletableFuture.runAsync(() ->
-                        requestManager.didSave(
-                                LspUtils.createDidSaveTextDocumentParams(
-                                        editor.getCurrentFileUri(), editor.getEditorContent()
-                                ))));
+        editor.getRequestManagerOfOptional().ifPresent(requestManager -> future = CompletableFuture.runAsync(() -> requestManager.didSave(LspUtils.createDidSaveTextDocumentParams(editor.getCurrentFileUri(), editor.getEditorContent()))));
 
         ForkJoinPool.commonPool().execute(future::join);
 

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/operations/format/RangeFormattingFeature.java
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/operations/format/RangeFormattingFeature.java
@@ -1,0 +1,104 @@
+/*
+ *    sora-editor - the awesome code editor for Android
+ *    https://github.com/Rosemoe/sora-editor
+ *    Copyright (C) 2020-2022  Rosemoe
+ *
+ *     This library is free software; you can redistribute it and/or
+ *     modify it under the terms of the GNU Lesser General Public
+ *     License as published by the Free Software Foundation; either
+ *     version 2.1 of the License, or (at your option) any later version.
+ *
+ *     This library is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *     Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public
+ *     License along with this library; if not, write to the Free Software
+ *     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *     USA
+ *
+ *     Please contact Rosemoe by email 2073412493@qq.com if you need
+ *     additional information or have any questions
+ */
+package io.github.rosemoe.sora.lsp.operations.format;
+
+import android.util.Pair;
+
+import androidx.annotation.WorkerThread;
+
+import org.eclipse.lsp4j.DocumentRangeFormattingParams;
+import org.eclipse.lsp4j.FormattingOptions;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import io.github.rosemoe.sora.lsp.client.languageserver.requestmanager.RequestManager;
+import io.github.rosemoe.sora.lsp.editor.LspEditor;
+import io.github.rosemoe.sora.lsp.operations.Feature;
+import io.github.rosemoe.sora.lsp.operations.document.ApplyEditsFeature;
+import io.github.rosemoe.sora.lsp.requests.Timeout;
+import io.github.rosemoe.sora.lsp.requests.Timeouts;
+import io.github.rosemoe.sora.lsp.utils.LSPException;
+import io.github.rosemoe.sora.lsp.utils.LspUtils;
+import io.github.rosemoe.sora.text.Content;
+import io.github.rosemoe.sora.text.TextRange;
+
+public class RangeFormattingFeature implements Feature<Pair<Content, TextRange>, Void> {
+
+    private CompletableFuture<Void> future;
+    private LspEditor editor;
+
+    @Override
+    public void install(LspEditor editor) {
+        this.editor = editor;
+    }
+
+    @Override
+    public void uninstall(LspEditor editor) {
+        this.editor = null;
+        if (future != null) {
+            future.cancel(true);
+            future = null;
+        }
+    }
+
+    @Override
+    @WorkerThread
+    public Void execute(Pair<Content, TextRange> data) {
+        RequestManager manager = editor.getRequestManager();
+
+        if (manager == null) {
+            return null;
+        }
+
+        //TODO: Separate features for full format and range formatting
+        var formattingParams = new DocumentRangeFormattingParams();
+        formattingParams.setOptions(editor.getOption(FormattingOptions.class));
+
+        formattingParams.setTextDocument(LspUtils.createTextDocumentIdentifier(editor.getCurrentFileUri()));
+        var textRange = data.second;
+        formattingParams.setRange(LspUtils.createRange(textRange));
+
+        var content = data.first;
+
+        future = manager.rangeFormatting(formattingParams).thenApply(list -> Optional.ofNullable(list).orElse(List.of())).thenAccept(list -> {
+            editor.safeUseFeature(ApplyEditsFeature.class)
+                    .ifPresent(applyEditsFeature -> applyEditsFeature
+                            .execute(new Pair<>(list, content)));
+
+        });
+
+
+        try {
+            future.get(Timeout.getTimeout(Timeouts.FORMATTING), TimeUnit.MILLISECONDS);
+        } catch (Exception exception) {
+            throw new LSPException("Formatting code timeout");
+        }
+        return null;
+    }
+
+
+}

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/utils/LspUtils.java
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/utils/LspUtils.java
@@ -47,7 +47,7 @@ import io.github.rosemoe.sora.text.TextRange;
 
 public class LspUtils {
 
-    private static Map<String, Integer> versionMap = new HashMap<>();
+    private static final Map<String, Integer> versionMap = new HashMap<>();
 
     public static DidCloseTextDocumentParams createDidCloseTextDocumentParams(String uri) {
         DidCloseTextDocumentParams params = new DidCloseTextDocumentParams();
@@ -66,7 +66,7 @@ public class LspUtils {
         return new TextDocumentContentChangeEvent(text);
     }
 
-    public static TextDocumentContentChangeEvent createTextDocumentContentChangeEvent(Range range,int rangeLength, String text) {
+    public static TextDocumentContentChangeEvent createTextDocumentContentChangeEvent(Range range, int rangeLength, String text) {
         return new TextDocumentContentChangeEvent(range, rangeLength, text);
     }
 
@@ -92,7 +92,10 @@ public class LspUtils {
 
 
     private static int getVersion(String uri) {
-        int version = versionMap.getOrDefault(uri, 0);
+        Integer version = versionMap.getOrDefault(uri, 0);
+        if (version == null) {
+            version = 0;
+        }
         version++;
         versionMap.put(uri, version);
         return version;


### PR DESCRIPTION
Add code snippet support in code completion for `editor-lsp`. 

like this :

![1661174244422_Trim_.gif](https://s2.loli.net/2022/08/22/s9C7HFrKXdJiANw.gif)

But it is not full code snippet support, because the editor does not yet provide support for code snippets.

So currently it only supports simple code snippets with Tabstops, the editor cursor will be moved to the first Tabstops position, other syntax (e.g. Choice, Placeholder, etc.) is not supported and will be replaced with empty string.

For the syntax of the code snippet, see [here](https://code.visualstudio.com/docs/editor/userdefinedsnippets).

