### PR TITLE
Fixed StackOverflowError in CodeEditor.copyLine()

### DIFF
--- a/editor/src/main/java/io/github/rosemoe/sora/widget/CodeEditor.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/CodeEditor.java
@@ -3118,7 +3118,7 @@ public class CodeEditor extends View implements ContentListener, Formatter.Forma
 
         final var line = cursor.left().line;
         setSelectionRegion(line, 0, line, getText().getColumnCount(line));
-        copyText();
+        copyText(false);
     }
 
     /**


### PR DESCRIPTION
This PR fixes a bug which causes `StackOverflowError` in the `CodeEditor.copyLine()` method.

## Reproduce this issue

An external keyboard or Hackers Keyboard is required to reproduce this.

Steps :
- Place the cursor on an empty line (not a blank line!).
- Press the `Ctrl + C` keybinding.