### PR TITLE
Remove xerces dependency

### DIFF
--- a/language-textmate/build.gradle.kts
+++ b/language-textmate/build.gradle.kts
@@ -51,7 +51,6 @@ dependencies {
     implementation("com.google.code.gson:gson:${Versions.gsonVersion}")
     implementation("org.jruby.jcodings:jcodings:${Versions.jcodingsVersion}")
     implementation("org.jruby.joni:joni:${Versions.joniVersion}")
-    implementation("xerces:xercesImpl:${Versions.xercesImplVersion}")
 
     implementation("org.yaml:snakeyaml:1.31")
     implementation("org.eclipse.jdt:org.eclipse.jdt.annotation:2.2.600")


### PR DESCRIPTION
In the new textmate update, these xml classes are no longer used. Proposing this PR as this dependency causes conflicts with the org.w3c.dom.html.HTMLDOMImplementation that our Ide already includes with the JAXP bundle