### PR TITLE
feature: custom bracket background by theme

### DIFF
--- a/app/src/main/assets/textmate/darcula.json
+++ b/app/src/main/assets/textmate/darcula.json
@@ -5,7 +5,8 @@
             "background": "#242424",
             "foreground": "#cccccc",
             "lineHighlight": "#2B2B2B",
-            "selection": "#214283"
+            "selection": "#214283",
+            "highlightedDelimetersForeground": "#57f6c0"
         }
     },
         {

--- a/language-textmate/src/main/java/io/github/rosemoe/sora/langs/textmate/TextMateColorScheme.java
+++ b/language-textmate/src/main/java/io/github/rosemoe/sora/langs/textmate/TextMateColorScheme.java
@@ -95,6 +95,12 @@ public class TextMateColorScheme extends EditorColorScheme {
                 setColor(TEXT_NORMAL, Color.parseColor(foreground));
             }
 
+            String highlightedDelimetersForeground =
+                    (String) themeRaw.get("highlightedDelimetersForeground");
+            if (highlightedDelimetersForeground != null) {
+                setColor(HIGHLIGHTED_DELIMITERS_FOREGROUND, Color.parseColor(foreground));
+            }
+
             //TMTheme seems to have no fields to control BLOCK_LINE colors
             int blockLineColor = ((getColor(WHOLE_BACKGROUND) + getColor(TEXT_NORMAL)) / 2) & 0x00FFFFFF | 0x88000000;
             setColor(BLOCK_LINE, blockLineColor);

--- a/language-textmate/src/main/java/io/github/rosemoe/sora/langs/textmate/TextMateColorScheme.java
+++ b/language-textmate/src/main/java/io/github/rosemoe/sora/langs/textmate/TextMateColorScheme.java
@@ -98,7 +98,7 @@ public class TextMateColorScheme extends EditorColorScheme {
             String highlightedDelimetersForeground =
                     (String) themeRaw.get("highlightedDelimetersForeground");
             if (highlightedDelimetersForeground != null) {
-                setColor(HIGHLIGHTED_DELIMITERS_FOREGROUND, Color.parseColor(foreground));
+                setColor(HIGHLIGHTED_DELIMITERS_FOREGROUND, Color.parseColor(highlightedDelimetersForeground));
             }
 
             //TMTheme seems to have no fields to control BLOCK_LINE colors


### PR DESCRIPTION
Now you can set custom bracket foreground color when it is selected by modifying the color scheme. It is useful when you have a dark background for editor and want the bracket foreground to be something lighter