### PR TITLE
Fixed: ContentReference.RefReader does not respect ContentLine.lineSeparator

### DIFF
--- a/editor/src/main/java/io/github/rosemoe/sora/text/ContentLine.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/text/ContentLine.java
@@ -336,4 +336,9 @@ public class ContentLine implements CharSequence, GetChars, BidiRequirementCheck
         }
         return lineSeparator;
     }
+
+    @NonNull
+    public char[] getLineSeparatorChars() {
+        return getLineSeparator().getChars();
+    }
 }

--- a/editor/src/main/java/io/github/rosemoe/sora/text/ContentReference.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/text/ContentReference.java
@@ -151,8 +151,9 @@ public class ContentReference extends TextReference {
                 column += toRead;
                 read += toRead;
                 if (read < length && columnCount == column) {
-                    chars[offset + read] = '\n';
-                    read++;
+                    var separator = content.getLine(line).getLineSeparatorChars();
+                    System.arraycopy(separator, 0, chars, offset + read, separator.length);
+                    read += separator.length;
                     line++;
                     column = 0;
                 }

--- a/editor/src/main/java/io/github/rosemoe/sora/text/LineSeparator.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/text/LineSeparator.java
@@ -54,6 +54,10 @@ public enum LineSeparator {
         return str;
     }
 
+    public char[] getChars() {
+        return getContent().toCharArray();
+    }
+
     public int getLength() {
         return length;
     }

--- a/editor/src/test/java/io/github/rosemoe/sora/text/ContentTest.kt
+++ b/editor/src/test/java/io/github/rosemoe/sora/text/ContentTest.kt
@@ -22,46 +22,35 @@
  *     additional information or have any questions
  ******************************************************************************/
 
-plugins {
-    id("com.android.library")
-    id("com.vanniktech.maven.publish.base")
-    id("kotlin-android")
-}
+package io.github.rosemoe.sora.text
 
-group = "io.github.Rosemoe.sora-editor"
-version = Versions.versionName
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
 
-android {
-    namespace = "io.github.rosemoe.sora"
+/**
+ * Tests for the [Content] class.
+ *
+ * @author Akash Yadav
+ */
+@RunWith(JUnit4::class)
+class ContentTest {
 
-    defaultConfig {
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-        consumerProguardFiles("consumer-rules.pro")
+    @Test
+    fun `test ContentReference should respect the line separator in ContentLine`() {
+        val content = Content("public class Main {\n" +
+                "    public static void main(String[] args) {\r\n" +
+                "        System.out.println(\"Hello World!\");\n" +
+                "    }\r\n" +
+                "}")
+
+        val ref = ContentReference(content)
+        val cString = ref.toReaderString()
+
+        // content[100] = 'W'
+        assert(cString[100] == content[100])
     }
 
-    buildTypes {
-        release {
-            isMinifyEnabled = false
-            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
-        }
-    }
 
-    kotlinOptions {
-        jvmTarget = "11"
-    }
-
-    testOptions {
-        unitTests {
-            isIncludeAndroidResources = true
-        }
-    }
-}
-
-dependencies {
-    api("androidx.annotation:annotation:1.4.0")
-    implementation("org.jetbrains.kotlin:kotlin-stdlib:${Versions.kotlinVersion}")
-
-    testImplementation("junit:junit:4.13.2")
-    androidTestImplementation("androidx.test.ext:junit:1.1.3")
-    androidTestImplementation("androidx.test.espresso:espresso-core:3.4.0")
+    private fun ContentReference.toReaderString() = createReader().use { it.readText() }
 }


### PR DESCRIPTION
The `ContentReference.RefReader` ignores the line separator for the `ContentLine` and appends `LF (\n)` instead. This PR fixes this issue.

Check out the `ContentTest` in `editor` module for more information.