### PR TITLE
Added more keybindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,17 @@ Download the newest sources from [Releases](https://github.com/Rosemoe/CodeEdito
 - [x] Incremental highlight analysis 
 - [x] Highlight bracket pairs 
 - [x] Event System
+
+## Key bindings
+
+When working with a physical keyboard, you can use use key bindings for performing various text actions.
+The editor provides support for some key bindings by default.
+However, you can subscribe to [`KeyBindingEvent`](https://github.com/Rosemoe/sora-editor/blob/main/editor/src/main/java/io/github/rosemoe/sora/event/KeyBindingEvent.java)
+and add your own key bindings. You can even override the default key bindings and perform actions of your own.
+
+The currently supported key bindings are mostly similar to Android Studio/Intellij IDEA.
+See the [supported key bindings](./keybindings.md).
+
 ## Screenshots
 <div style="overflow: hidden">
 <img src="/images/general.jpg" alt="GeneralAppearance" width="40%" align="bottom" />

--- a/app/src/main/java/io/github/rosemoe/sora/app/MainActivity.kt
+++ b/app/src/main/java/io/github/rosemoe/sora/app/MainActivity.kt
@@ -237,7 +237,7 @@ class MainActivity : AppCompatActivity() {
 
     private fun updatePositionText() {
         val cursor = binding.editor.cursor
-        var text = (1 + cursor.leftLine).toString() + ":" + cursor.leftColumn + " "
+        var text = (1 + cursor.leftLine).toString() + ":" + cursor.leftColumn + ";" + cursor.left + " "
         text += if (cursor.isSelected) {
             "(" + (cursor.right - cursor.left) + " chars)"
         } else {

--- a/editor/src/main/java/io/github/rosemoe/sora/text/CharPosition.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/text/CharPosition.java
@@ -43,6 +43,18 @@ public final class CharPosition {
 
     public int column;
 
+    public CharPosition() {}
+
+    public CharPosition(int line, int column) {
+        this(line, column, -1);
+    }
+
+    public CharPosition(int line, int column, int index) {
+        this.index = index;
+        this.line = line;
+        this.column = column;
+    }
+
     /**
      * Get the index
      *

--- a/editor/src/main/java/io/github/rosemoe/sora/util/Chars.kt
+++ b/editor/src/main/java/io/github/rosemoe/sora/util/Chars.kt
@@ -64,7 +64,7 @@ object Chars {
             position.column -= 1
         }
         if (position.column <= 0 && position.line > 0 && reverse) {
-            val l = position.line
+            val l = position.line - 1
             val pos = CharPosition(l, text.getLine(l).length)
             return TextRange(pos, pos)
         }
@@ -136,7 +136,7 @@ object Chars {
             }
 
             val c = text[i]
-            if (!c.isWhitespace()) break
+            if (!c.isWhitespace() || (i == 0 && reverse)) break
             else {
                 i += if (reverse) -1 else 1
             }

--- a/editor/src/main/java/io/github/rosemoe/sora/util/Chars.kt
+++ b/editor/src/main/java/io/github/rosemoe/sora/util/Chars.kt
@@ -60,9 +60,20 @@ object Chars {
     @JvmStatic
     @JvmOverloads
     fun findWord(position: CharPosition, text: Content, reverse: Boolean = false): TextRange {
-        if (text.getColumnCount(position.line) == position.column && position.line < text.lineCount - 1) {
-            return TextRange(CharPosition(position.line + 1, 0), CharPosition(position.line + 1, 0))
+        if(reverse) {
+            position.column -= 1
         }
+        if (position.column <= 0 && position.line > 0 && reverse) {
+            val l = position.line
+            val pos = CharPosition(l, text.getLine(l).length)
+            return TextRange(pos, pos)
+        }
+
+        if (text.getColumnCount(position.line) == position.column && position.line < text.lineCount - 1 && !reverse) {
+            val pos = CharPosition(position.line + 1, 0)
+            return TextRange(pos, pos)
+        }
+
         val column = skipWs(text.getLine(position.line), position.column, reverse)
         return getWordRange(text, position.line, column, false)
     }

--- a/editor/src/main/java/io/github/rosemoe/sora/util/Chars.kt
+++ b/editor/src/main/java/io/github/rosemoe/sora/util/Chars.kt
@@ -1,0 +1,135 @@
+/*******************************************************************************
+ *    sora-editor - the awesome code editor for Android
+ *    https://github.com/Rosemoe/sora-editor
+ *    Copyright (C) 2020-2022  Rosemoe
+ *
+ *     This library is free software; you can redistribute it and/or
+ *     modify it under the terms of the GNU Lesser General Public
+ *     License as published by the Free Software Foundation; either
+ *     version 2.1 of the License, or (at your option) any later version.
+ *
+ *     This library is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *     Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public
+ *     License along with this library; if not, write to the Free Software
+ *     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *     USA
+ *
+ *     Please contact Rosemoe by email 2073412493@qq.com if you need
+ *     additional information or have any questions
+ ******************************************************************************/
+
+package io.github.rosemoe.sora.util
+
+import io.github.rosemoe.sora.text.CharPosition
+import io.github.rosemoe.sora.text.Content
+import io.github.rosemoe.sora.text.ICUUtils
+import io.github.rosemoe.sora.text.TextRange
+
+/**
+ * Utility class for working with characters and indexes.
+ *
+ * @author Akash Yadav
+ */
+object Chars {
+
+    /**
+     * Find the previous word and get its start position.
+     */
+    @JvmStatic
+    fun prevWordStart(position: CharPosition, text: Content): CharPosition {
+        return findWord(position, text, true).start
+    }
+
+    /**
+     * Find the next word and get its end position.
+     */
+    @JvmStatic
+    fun nextWordEnd(position: CharPosition, text: Content): CharPosition {
+        return findWord(position, text).end
+    }
+
+    /**
+     * Find the previous/next word from the given [character position][position] in the given [text].
+     *
+     * @param reverse Whether to search for word in reverse or not.
+     */
+    @JvmStatic
+    @JvmOverloads
+    fun findWord(position: CharPosition, text: Content, reverse: Boolean = false): TextRange {
+        if (text.getColumnCount(position.line) == position.column && position.line < text.lineCount - 1) {
+            return TextRange(CharPosition(position.line + 1, 0), CharPosition(position.line + 1, 0))
+        }
+        val column = skipWs(text.getLine(position.line), position.column, reverse)
+        return getWordRange(text, position.line, column, false)
+    }
+
+    /**
+     * Get the range of the word at given character position.
+     *
+     * @param line   The line.
+     * @param column The column.
+     * @param useIcu Whether to use the ICU library to get word edges.
+     * @return The word range.
+     */
+    @JvmStatic
+    fun getWordRange(text: Content, line: Int, column: Int, useIcu: Boolean): TextRange {
+        // Find word edges
+        var startLine = line
+        var endLine = line
+        val lineObj = text.getLine(line)
+        val edges = ICUUtils.getWordEdges(lineObj, column, useIcu)
+        val startOffset = IntPair.getFirst(edges)
+        val endOffset = IntPair.getSecond(edges)
+        var startColumn = startOffset
+        var endColumn = endOffset
+        if (startColumn == endColumn) {
+            if (endColumn < lineObj.length) {
+                endColumn++
+            } else if (startColumn > 0) {
+                startColumn--
+            } else {
+                if (line > 0) {
+                    val lastColumn = text.getColumnCount(line - 1)
+                    startLine = line - 1
+                    startColumn = lastColumn
+                } else if (line < text.lineCount - 1) {
+                    endLine = line + 1
+                    endColumn = 0
+                }
+            }
+        }
+        return TextRange(
+            CharPosition(startLine, startColumn, startOffset),
+            CharPosition(endLine, endColumn, endOffset)
+        )
+    }
+
+    /**
+     * Find the next/previous offset after/before [offset] skipping all the whitespaces.
+     *
+     * @param text The text.
+     * @param offset The offset to start from.
+     * @param reverse Whether to skip whitespaces towards index 0 or `text.length`.
+     */
+    @JvmStatic
+    @JvmOverloads
+    fun skipWs(text: CharSequence, offset: Int, reverse: Boolean = false): Int {
+        var i = offset
+        while (true) {
+            if ((reverse && i < 0) || (!reverse && i == text.length)) {
+                break
+            }
+
+            val c = text[i]
+            if (!c.isWhitespace()) break
+            else {
+                i += if (reverse) -1 else 1
+            }
+        }
+        return i
+    }
+}

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/CodeEditor.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/CodeEditor.java
@@ -105,6 +105,7 @@ import io.github.rosemoe.sora.text.TextLayoutHelper;
 import io.github.rosemoe.sora.text.TextRange;
 import io.github.rosemoe.sora.text.TextUtils;
 import io.github.rosemoe.sora.text.method.KeyMetaStates;
+import io.github.rosemoe.sora.util.Chars;
 import io.github.rosemoe.sora.util.Floats;
 import io.github.rosemoe.sora.util.IntPair;
 import io.github.rosemoe.sora.util.Logger;
@@ -2006,8 +2007,8 @@ public class CodeEditor extends View implements ContentListener, Formatter.Forma
      * extra space is added.
      *
      * @param extraSpaceFactor the factor. 0.5 by default.
-     * @see #getVerticalExtraSpaceFactor()
      * @throws IllegalArgumentException if the factor is negative or bigger than 1.0f
+     * @see #getVerticalExtraSpaceFactor()
      */
     public void setVerticalExtraSpaceFactor(float extraSpaceFactor) {
         if (extraSpaceFactor < 0 || extraSpaceFactor > 1.0f) {
@@ -3429,30 +3430,30 @@ public class CodeEditor extends View implements ContentListener, Formatter.Forma
      * @param column The column.
      */
     public void selectWord(int line, int column) {
-        // Find word edges
-        int startLine = line, endLine = line;
-        var lineObj = getText().getLine(line);
-        long edges = ICUUtils.getWordEdges(lineObj, column, props.useICULibToSelectWords);
-        int startColumn = IntPair.getFirst(edges);
-        int endColumn = IntPair.getSecond(edges);
-        if (startColumn == endColumn) {
-            if (endColumn < lineObj.length()) {
-                endColumn++;
-            } else if (startColumn > 0) {
-                startColumn--;
-            } else {
-                if (line > 0) {
-                    int lastColumn = getText().getColumnCount(line - 1);
-                    startLine = line - 1;
-                    startColumn = lastColumn;
-                } else if (line < getLineCount() - 1) {
-                    endLine = line + 1;
-                    endColumn = 0;
-                }
-            }
-        }
+        final var range = getWordRange(line, column);
+        final var start = range.getStart();
+        final var end = range.getEnd();
         requestFocusFromTouch();
-        setSelectionRegion(startLine, startColumn, endLine, endColumn, SelectionChangeEvent.CAUSE_LONG_PRESS);
+        setSelectionRegion(start.line, start.column, end.line, end.column, SelectionChangeEvent.CAUSE_LONG_PRESS);
+    }
+
+    /**
+     * @see #getWordRange(int, int, boolean)
+     */
+    public TextRange getWordRange(final int line, final int column) {
+        return getWordRange(line, column, props.useICULibToSelectWords);
+    }
+
+    /**
+     * Get the range of the word at given character position.
+     *
+     * @param line   The line.
+     * @param column The column.
+     * @param useIcu Whether to use the ICU library to get word edges.
+     * @return The word range.
+     */
+    public TextRange getWordRange(final int line, final int column, final boolean useIcu) {
+        return Chars.getWordRange(getText(), line, column, useIcu);
     }
 
     /**

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/CodeEditor.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/CodeEditor.java
@@ -2915,7 +2915,7 @@ public class CodeEditor extends View implements ContentListener, Formatter.Forma
     /**
      * Make sure the moving selection is visible
      */
-    private void ensureSelectingTargetVisible() {
+    void ensureSelectingTargetVisible() {
         if (cursor.left().equals(selectionAnchor)) {
             // Ensure right selection visible
             ensureSelectionVisible();

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/CodeEditor.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/CodeEditor.java
@@ -3435,6 +3435,7 @@ public class CodeEditor extends View implements ContentListener, Formatter.Forma
         final var end = range.getEnd();
         requestFocusFromTouch();
         setSelectionRegion(start.line, start.column, end.line, end.column, SelectionChangeEvent.CAUSE_LONG_PRESS);
+        selectionAnchor = getCursor().left();
     }
 
     /**

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/CodeEditor.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/CodeEditor.java
@@ -98,7 +98,6 @@ import io.github.rosemoe.sora.text.ContentLine;
 import io.github.rosemoe.sora.text.ContentListener;
 import io.github.rosemoe.sora.text.ContentReference;
 import io.github.rosemoe.sora.text.Cursor;
-import io.github.rosemoe.sora.text.ICUUtils;
 import io.github.rosemoe.sora.text.LineRemoveListener;
 import io.github.rosemoe.sora.text.LineSeparator;
 import io.github.rosemoe.sora.text.TextLayoutHelper;
@@ -923,21 +922,34 @@ public class CodeEditor extends View implements ContentListener, Formatter.Forma
      * @return <code>true</code> if the editor can handle the keybinding, <code>false</code> otherwise.
      */
     protected boolean canHandleKeyBinding(int keyCode, boolean ctrlPressed, boolean shiftPressed, boolean altPressed) {
-        if (ctrlPressed && !shiftPressed && altPressed) {
-            return keyCode == KeyEvent.KEYCODE_A || keyCode == KeyEvent.KEYCODE_C
-                    || keyCode == KeyEvent.KEYCODE_X || keyCode == KeyEvent.KEYCODE_V
-                    || keyCode == KeyEvent.KEYCODE_U || keyCode == KeyEvent.KEYCODE_R
-                    || keyCode == KeyEvent.KEYCODE_D || keyCode == KeyEvent.KEYCODE_W;
-        }
+        final var isDpadKey = keyCode == KeyEvent.KEYCODE_DPAD_UP || keyCode == KeyEvent.KEYCODE_DPAD_DOWN
+                || keyCode == KeyEvent.KEYCODE_DPAD_LEFT || keyCode == KeyEvent.KEYCODE_DPAD_RIGHT;
+        final var isHomeOrEnd = keyCode == KeyEvent.KEYCODE_MOVE_HOME || keyCode == KeyEvent.KEYCODE_MOVE_END;
 
-        if (shiftPressed && !altPressed) {
-            if (ctrlPressed) {
-                // Ctrl + Shift + J
-                return keyCode == KeyEvent.KEYCODE_J;
-            } else {
-                // Shift + Enter
+        if (ctrlPressed) {
+            if (shiftPressed) {
+                // Ctrl+Shift+[xx] keys
+                return isDpadKey || isHomeOrEnd || keyCode == KeyEvent.KEYCODE_J;
+            }
+
+            if (altPressed) {
+                // Ctrl+Alt+[xx] keys
                 return keyCode == KeyEvent.KEYCODE_ENTER;
             }
+
+            // Ctrl+[xx] keys
+            return isDpadKey || isHomeOrEnd
+                    || keyCode == KeyEvent.KEYCODE_A || keyCode == KeyEvent.KEYCODE_C
+                    || keyCode == KeyEvent.KEYCODE_X || keyCode == KeyEvent.KEYCODE_V
+                    || keyCode == KeyEvent.KEYCODE_U || keyCode == KeyEvent.KEYCODE_R
+                    || keyCode == KeyEvent.KEYCODE_D || keyCode == KeyEvent.KEYCODE_W
+                    || keyCode == KeyEvent.KEYCODE_ENTER;
+        }
+
+
+        if (shiftPressed) {
+            // Shift+[xx] keys
+            return isDpadKey || isHomeOrEnd || keyCode == KeyEvent.KEYCODE_ENTER;
         }
 
         return false;

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/EditorKeyEventHandler.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/EditorKeyEventHandler.java
@@ -169,6 +169,7 @@ class EditorKeyEventHandler {
     ) {
         final var connection = editor.inputConnection;
         final var editorCursor = editor.getCursor();
+        final var editorText = editor.getText();
         final var completionWindow = editor.getComponent(EditorAutoCompletion.class);
         switch (keyCode) {
             case KeyEvent.KEYCODE_BACK: {
@@ -207,8 +208,14 @@ class EditorKeyEventHandler {
                 editor.moveSelectionRight();
                 return editorKeyEvent.result(true);
             case KeyEvent.KEYCODE_MOVE_END:
-                editor.moveSelectionEnd();
-                return editorKeyEvent.result(true);
+                if (isCtrlPressed) {
+                    final var lastLine = editorText.getLineCount() - 1;
+                    final var lastColumn = editorText.getColumnCount(lastLine);
+                    editor.setSelection(lastLine, lastColumn);
+                    return editorKeyEvent.result(true);
+                }
+            editor.moveSelectionEnd();
+            return editorKeyEvent.result(true);
             case KeyEvent.KEYCODE_MOVE_HOME:
                 if (isCtrlPressed) {
                     editor.setSelection(0, 0);

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/EditorKeyEventHandler.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/EditorKeyEventHandler.java
@@ -218,10 +218,17 @@ class EditorKeyEventHandler {
                         editorText.endBatchEdit();
 
                         // Update selection
+                        final var newLeft = new CharPosition(left.line + 1, left.column);
+                        final var newRight = new CharPosition(right.line + 1, right.column);
                         if (left.index != right.index) {
-                            editor.setSelectionRegion(left.line + 1, left.column, right.line + 1, right.column);
+                            editor.setSelectionRegion(newLeft.line, newLeft.column, newRight.line, newRight.column);
+                            if (editor.selectionAnchor.equals(left)) {
+                                editor.selectionAnchor = newLeft;
+                            } else {
+                                editor.selectionAnchor = newRight;
+                            }
                         } else {
-                            editor.setSelection(left.line + 1, left.column);
+                            editor.setSelection(newLeft.line, newLeft.column);
                         }
 
                         return editorKeyEvent.result(true);
@@ -252,10 +259,17 @@ class EditorKeyEventHandler {
                         editorText.endBatchEdit();
 
                         // Update selection
+                        final var newLeft = new CharPosition(left.line - 1, left.column);
+                        final var newRight = new CharPosition(right.line - 1, right.column);
                         if (left.index != right.index) {
-                            editor.setSelectionRegion(left.line - 1, left.column, right.line - 1, right.column);
+                            editor.setSelectionRegion(newLeft.line, newLeft.column, newRight.line, newRight.column);
+                            if (editor.selectionAnchor.equals(left)) {
+                                editor.selectionAnchor = newLeft;
+                            } else {
+                                editor.selectionAnchor = newRight;
+                            }
                         } else {
-                            editor.setSelection(left.line - 1, left.column);
+                            editor.setSelection(newLeft.line, newLeft.column);
                         }
 
                         return editorKeyEvent.result(true);

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/EditorKeyEventHandler.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/EditorKeyEventHandler.java
@@ -203,6 +203,17 @@ class EditorKeyEventHandler {
                 editor.moveSelectionUp();
                 return editorKeyEvent.result(true);
             case KeyEvent.KEYCODE_DPAD_LEFT:
+                if (isCtrlPressed) {
+                    final var handle = editorCursor.left().equals(editor.selectionAnchor) ? editorCursor.right() : editorCursor.left();
+                    final var prevStart = Chars.prevWordStart(handle, editorText);
+                    if (editor.selectionAnchor != null) {
+                        editor.setSelectionRegion(editor.selectionAnchor.line, editor.selectionAnchor.column, prevStart.line, prevStart.column);
+                        editor.ensureSelectingTargetVisible();
+                        return editorKeyEvent.result(true);
+                    }
+                    editor.setSelection(prevStart.line, prevStart.column);
+                    return editorKeyEvent.result(true);
+                }
                 editor.moveSelectionLeft();
                 return editorKeyEvent.result(true);
             case KeyEvent.KEYCODE_DPAD_RIGHT:

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/EditorKeyEventHandler.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/EditorKeyEventHandler.java
@@ -253,7 +253,7 @@ class EditorKeyEventHandler {
 
                         // Update selection
                         if (left.index != right.index) {
-                            editor.setSelectionRegion(left.line - 1, left.column, right.line + 1, right.column);
+                            editor.setSelectionRegion(left.line - 1, left.column, right.line - 1, right.column);
                         } else {
                             editor.setSelection(left.line - 1, left.column);
                         }

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/EditorKeyEventHandler.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/EditorKeyEventHandler.java
@@ -207,7 +207,8 @@ class EditorKeyEventHandler {
                 return editorKeyEvent.result(true);
             case KeyEvent.KEYCODE_DPAD_RIGHT:
                 if (isCtrlPressed) {
-                    final var nextEnd = Chars.nextWordEnd(editorCursor.left(), editorText);
+                    final var handle = editorCursor.left().equals(editor.selectionAnchor) ? editorCursor.right() : editorCursor.left();
+                    final var nextEnd = Chars.nextWordEnd(handle, editorText);
                     if (editor.selectionAnchor != null) {
                         editor.setSelectionRegion(editor.selectionAnchor.line, editor.selectionAnchor.column, nextEnd.line, nextEnd.column);
                         editor.ensureSelectingTargetVisible();

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/EditorKeyEventHandler.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/EditorKeyEventHandler.java
@@ -224,6 +224,22 @@ class EditorKeyEventHandler {
                 return editorKeyEvent.result(true);
             case KeyEvent.KEYCODE_DPAD_UP:
                 if (isCtrlPressed) {
+                    if (isShiftPressed) {
+                        final var left = editorCursor.left();
+                        final var right = editorCursor.right();
+                        final var lines = editorText.getLineCount();
+                        if (left.line == 0) {
+                            // first line, cannot move up
+                            return editorKeyEvent.result(true);
+                        }
+
+                        final var prev = editorText.getLine(left.line - 1).toString();
+                        editorText.beginBatchEdit();
+                        editorText.delete(left.line - 1, 0, left.line, 0);
+                        editorText.insert(right.line - 1, editorText.getColumnCount(right.line - 1), editor.getLineSeparator().getContent().concat(prev));
+                        editorText.endBatchEdit();
+                        return editorKeyEvent.result(true);
+                    }
                     if (editor.getOffsetY() == 0) {
                         return editorKeyEvent.result(true);
                     }

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/EditorKeyEventHandler.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/EditorKeyEventHandler.java
@@ -210,8 +210,12 @@ class EditorKeyEventHandler {
                 editor.moveSelectionEnd();
                 return editorKeyEvent.result(true);
             case KeyEvent.KEYCODE_MOVE_HOME:
-                editor.moveSelectionHome();
-                return editorKeyEvent.result(true);
+                if (isCtrlPressed) {
+                    editor.setSelection(0, 0);
+                    return editorKeyEvent.result(true);
+                }
+            editor.moveSelectionHome();
+            return editorKeyEvent.result(true);
             case KeyEvent.KEYCODE_PAGE_DOWN:
                 editor.movePageDown();
                 return editorKeyEvent.result(true);
@@ -319,9 +323,10 @@ class EditorKeyEventHandler {
             KeyBindingEvent keybindingEvent,
             int keyCode,
             boolean isShiftPressed) {
-        final var connection = this.editor.inputConnection;
-        final var editorText = this.editor.getText();
-        final var editorCursor = this.editor.getCursor();
+        final var editor = this.editor;
+        final var connection = editor.inputConnection;
+        final var editorText = editor.getText();
+        final var editorCursor = editor.getCursor();
         switch (keyCode) {
             case KeyEvent.KEYCODE_V:
                 if (editor.isEditable()) {

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/EditorKeyEventHandler.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/EditorKeyEventHandler.java
@@ -39,6 +39,7 @@ import io.github.rosemoe.sora.text.CharPosition;
 import io.github.rosemoe.sora.text.Content;
 import io.github.rosemoe.sora.text.Cursor;
 import io.github.rosemoe.sora.text.method.KeyMetaStates;
+import io.github.rosemoe.sora.util.Chars;
 import io.github.rosemoe.sora.widget.component.EditorAutoCompletion;
 
 /**
@@ -205,25 +206,39 @@ class EditorKeyEventHandler {
                 editor.moveSelectionLeft();
                 return editorKeyEvent.result(true);
             case KeyEvent.KEYCODE_DPAD_RIGHT:
+                if (isCtrlPressed) {
+                    final var nextEnd = Chars.nextWordEnd(editorCursor.left(), editorText);
+                    if (editor.selectionAnchor != null) {
+                        editor.setSelectionRegion(editor.selectionAnchor.line, editor.selectionAnchor.column, nextEnd.line, nextEnd.column);
+                        editor.ensureSelectingTargetVisible();
+                        return editorKeyEvent.result(true);
+                    }
+                    editor.setSelection(nextEnd.line, nextEnd.column);
+                    return editorKeyEvent.result(true);
+                }
                 editor.moveSelectionRight();
                 return editorKeyEvent.result(true);
             case KeyEvent.KEYCODE_MOVE_END:
                 final var lastLine = editorText.getLineCount() - 1;
                 final var lastColumn = editorText.getColumnCount(lastLine);
-                if (isCtrlPressed && editor.selectionAnchor != null) {
-                    editor.setSelectionRegion(editor.selectionAnchor.line, editor.selectionAnchor.column, lastLine, lastColumn);
-                    editor.ensureSelectingTargetVisible();
-                } else if (isCtrlPressed) {
+                if (isCtrlPressed) {
+                    if (editor.selectionAnchor != null) {
+                        editor.setSelectionRegion(editor.selectionAnchor.line, editor.selectionAnchor.column, lastLine, lastColumn);
+                        editor.ensureSelectingTargetVisible();
+                        return editorKeyEvent.result(true);
+                    }
                     editor.setSelection(lastLine, lastColumn);
                     return editorKeyEvent.result(true);
                 }
                 editor.moveSelectionEnd();
                 return editorKeyEvent.result(true);
             case KeyEvent.KEYCODE_MOVE_HOME:
-                if (isCtrlPressed && editor.selectionAnchor != null) {
-                    editor.setSelectionRegion(0, 0, editor.selectionAnchor.line, editor.selectionAnchor.column);
-                    editor.ensureSelectingTargetVisible();
-                } else if (isCtrlPressed) {
+                if (isCtrlPressed) {
+                    if (editor.selectionAnchor != null) {
+                        editor.setSelectionRegion(0, 0, editor.selectionAnchor.line, editor.selectionAnchor.column);
+                        editor.ensureSelectingTargetVisible();
+                        return editorKeyEvent.result(true);
+                    }
                     editor.setSelection(0, 0);
                     return editorKeyEvent.result(true);
                 }

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/EditorKeyEventHandler.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/EditorKeyEventHandler.java
@@ -198,6 +198,22 @@ class EditorKeyEventHandler {
             }
             case KeyEvent.KEYCODE_DPAD_DOWN:
                 if (isCtrlPressed) {
+                    if (isShiftPressed) {
+                        final var left = editorCursor.left();
+                        final var right = editorCursor.right();
+                        final var lines = editorText.getLineCount();
+                        if (right.line == lines - 1) {
+                            // last line, cannot move down
+                            return editorKeyEvent.result(true);
+                        }
+
+                        final var next = editorText.getLine(right.line + 1).toString();
+                        editorText.beginBatchEdit();
+                        editorText.delete(right.line, editorText.getColumnCount(right.line), right.line + 1, next.length());
+                        editorText.insert(left.line, 0, next.concat(editor.getLineSeparator().getContent()));
+                        editorText.endBatchEdit();
+                        return editorKeyEvent.result(true);
+                    }
                     editor.getScroller().startScroll(editor.getOffsetX(), editor.getOffsetY(), 0, editor.getRowHeight());
                     return editorKeyEvent.result(true);
                 }

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/EditorKeyEventHandler.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/EditorKeyEventHandler.java
@@ -208,21 +208,27 @@ class EditorKeyEventHandler {
                 editor.moveSelectionRight();
                 return editorKeyEvent.result(true);
             case KeyEvent.KEYCODE_MOVE_END:
-                if (isCtrlPressed) {
-                    final var lastLine = editorText.getLineCount() - 1;
-                    final var lastColumn = editorText.getColumnCount(lastLine);
+                final var lastLine = editorText.getLineCount() - 1;
+                final var lastColumn = editorText.getColumnCount(lastLine);
+                if (isCtrlPressed && editor.selectionAnchor != null) {
+                    editor.setSelectionRegion(editor.selectionAnchor.line, editor.selectionAnchor.column, lastLine, lastColumn);
+                    editor.ensureSelectingTargetVisible();
+                } else if (isCtrlPressed) {
                     editor.setSelection(lastLine, lastColumn);
                     return editorKeyEvent.result(true);
                 }
-            editor.moveSelectionEnd();
-            return editorKeyEvent.result(true);
+                editor.moveSelectionEnd();
+                return editorKeyEvent.result(true);
             case KeyEvent.KEYCODE_MOVE_HOME:
-                if (isCtrlPressed) {
+                if (isCtrlPressed && editor.selectionAnchor != null) {
+                    editor.setSelectionRegion(0, 0, editor.selectionAnchor.line, editor.selectionAnchor.column);
+                    editor.ensureSelectingTargetVisible();
+                } else if (isCtrlPressed) {
                     editor.setSelection(0, 0);
                     return editorKeyEvent.result(true);
                 }
-            editor.moveSelectionHome();
-            return editorKeyEvent.result(true);
+                editor.moveSelectionHome();
+                return editorKeyEvent.result(true);
             case KeyEvent.KEYCODE_PAGE_DOWN:
                 editor.movePageDown();
                 return editorKeyEvent.result(true);

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/EditorKeyEventHandler.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/EditorKeyEventHandler.java
@@ -27,6 +27,7 @@ import android.util.Log;
 import android.view.KeyEvent;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import java.util.Objects;
 
@@ -72,10 +73,21 @@ class EditorKeyEventHandler {
      * @return <code>true</code> if the event is a key binding event. <code>false</code> otherwise.
      */
     private boolean isKeyBindingEvent(int keyCode, KeyEvent event) {
-        return (keyMetaStates.isShiftPressed()
-                || keyMetaStates.isAltPressed()
-                || event.isCtrlPressed())
-                && ((keyCode >= KeyEvent.KEYCODE_A && keyCode <= KeyEvent.KEYCODE_Z) || keyCode == KeyEvent.KEYCODE_ENTER);
+
+        // These keys must be pressed for the key event to be a key binding event
+        if (!(keyMetaStates.isShiftPressed() || keyMetaStates.isAltPressed() || event.isCtrlPressed())) {
+            return false;
+        }
+
+        // Any alphabet key
+        if (keyCode >= KeyEvent.KEYCODE_A && keyCode <= KeyEvent.KEYCODE_Z) {
+            return true;
+        }
+
+        // Other key combinations
+        return keyCode == KeyEvent.KEYCODE_ENTER
+                || keyCode == KeyEvent.KEYCODE_MOVE_HOME
+                || keyCode == KeyEvent.KEYCODE_MOVE_END;
     }
 
     /**
@@ -99,20 +111,16 @@ class EditorKeyEventHandler {
         keyMetaStates.onKeyDown(event);
         final var editor = this.editor;
         final var eventManager = editor.eventManager;
-        final var connection = editor.inputConnection;
-        final var editorCursor = editor.getCursor();
-        final var editorText = editor.getText();
-        final var completionWindow = editor.getComponent(EditorAutoCompletion.class);
 
-        final var e = new EditorKeyEvent(editor, event, EditorKeyEvent.Type.DOWN);
+        final var editorKeyEvent = new EditorKeyEvent(editor, event, EditorKeyEvent.Type.DOWN);
         final var keybindingEvent =
                 new KeyBindingEvent(editor,
                         event,
                         EditorKeyEvent.Type.DOWN,
                         keyCode,
                         editor.canHandleKeyBinding(keyCode, event.isCtrlPressed(), keyMetaStates.isShiftPressed(), keyMetaStates.isAltPressed()));
-        if ((eventManager.dispatchEvent(e) & InterceptTarget.TARGET_EDITOR) != 0) {
-            return e.result(false);
+        if ((eventManager.dispatchEvent(editorKeyEvent) & InterceptTarget.TARGET_EDITOR) != 0) {
+            return editorKeyEvent.result(false);
         }
 
         final var isShiftPressed = keyMetaStates.isShiftPressed();
@@ -123,7 +131,7 @@ class EditorKeyEventHandler {
         // Should we add support for more keys?
         if (isKeyBindingEvent(keyCode, event)) {
             if ((eventManager.dispatchEvent(keybindingEvent) & InterceptTarget.TARGET_EDITOR) != 0) {
-                return keybindingEvent.result(false) || e.result(false);
+                return keybindingEvent.result(false) || editorKeyEvent.result(false);
             }
         }
 
@@ -134,129 +142,82 @@ class EditorKeyEventHandler {
             case KeyEvent.KEYCODE_DPAD_RIGHT:
             case KeyEvent.KEYCODE_MOVE_HOME:
             case KeyEvent.KEYCODE_MOVE_END:
-                if (isShiftPressed && (!editorCursor.isSelected())) {
-                    editor.selectionAnchor = editorCursor.left();
+                final var cursor = editor.getCursor();
+                if (isShiftPressed && (!cursor.isSelected())) {
+                    editor.selectionAnchor = cursor.left();
                 } else if (!isShiftPressed && editor.selectionAnchor != null) {
                     editor.selectionAnchor = null;
                 }
                 keyMetaStates.adjust();
         }
 
+        Boolean result = handleKeyEvent(event, editorKeyEvent, keybindingEvent, keyCode, isShiftPressed, isAltPressed, isCtrlPressed);
+        if (result != null) {
+            return result;
+        }
+
+        return editorKeyEvent.result(editor.onSuperKeyDown(keyCode, event));
+    }
+
+    private Boolean handleKeyEvent(KeyEvent event,
+                                   EditorKeyEvent editorKeyEvent,
+                                   KeyBindingEvent keybindingEvent,
+                                   int keyCode,
+                                   boolean isShiftPressed,
+                                   boolean isAltPressed,
+                                   boolean isCtrlPressed
+    ) {
+        final var connection = editor.inputConnection;
+        final var editorCursor = editor.getCursor();
+        final var completionWindow = editor.getComponent(EditorAutoCompletion.class);
         switch (keyCode) {
             case KeyEvent.KEYCODE_BACK: {
                 if (editorCursor.isSelected()) {
                     editor.setSelection(editorCursor.getLeftLine(), editorCursor.getLeftColumn());
-                    return e.result(true);
+                    return editorKeyEvent.result(true);
                 }
-                return e.result(false);
+                return editorKeyEvent.result(false);
             }
             case KeyEvent.KEYCODE_DEL:
                 if (editor.isEditable()) {
                     editor.deleteText();
                     editor.notifyIMEExternalCursorChange();
                 }
-                return e.result(true);
+                return editorKeyEvent.result(true);
             case KeyEvent.KEYCODE_FORWARD_DEL: {
                 if (editor.isEditable()) {
                     connection.deleteSurroundingText(0, 1);
                     editor.notifyIMEExternalCursorChange();
                 }
-                return e.result(true);
+                return editorKeyEvent.result(true);
             }
             case KeyEvent.KEYCODE_ENTER: {
-                if (editor.isEditable()) {
-                    var lineSeparator = editor.getLineSeparator().getContent();
-                    final var editorLanguage = editor.getEditorLanguage();
-                    if (completionWindow.isShowing() && completionWindow.select()) {
-                        return true;
-                    }
-
-                    if (isShiftPressed && !isAltPressed && !isCtrlPressed) {
-                        // Shift + Enter
-                        return startNewLIne(editor, editorCursor, editorText, e, keybindingEvent);
-                    }
-
-                    if (isCtrlPressed && !isShiftPressed) {
-                        if (isAltPressed) {
-                            // Ctrl + Alt + Enter
-                            var line = editorCursor.left().line;
-                            if (line == 0) {
-                                editorText.insert(0, 0, lineSeparator);
-                                editor.setSelection(0, 0);
-                                editor.ensureSelectionVisible();
-                                return keybindingEvent.result(true) || e.result(true);
-                            } else {
-                                line--;
-                                editor.setSelection(line, editorText.getColumnCount(line));
-                                return startNewLIne(editor, editorCursor, editorText, e, keybindingEvent);
-                            }
-                        }
-
-                        // Ctrl + Enter
-                        final var left = editorCursor.left().fromThis();
-                        editor.commitText(lineSeparator);
-                        editor.setSelection(left.line, left.column);
-                        editor.ensureSelectionVisible();
-                        return keybindingEvent.result(true) || e.result(true);
-                    }
-
-                    NewlineHandler[] handlers = editorLanguage.getNewlineHandlers();
-                    if (handlers == null || editorCursor.isSelected()) {
-                        editor.commitText(lineSeparator, true);
-                    } else {
-                        boolean consumed = false;
-                        for (NewlineHandler handler : handlers) {
-                            if (handler != null) {
-                                if (handler.matchesRequirement(editorText, editorCursor.left(), editor.getStyles())) {
-                                    try {
-                                        var result = handler.handleNewline(editorText, editorCursor.left(), editor.getStyles(), editor.getTabWidth());
-                                        editor.commitText(result.text, false);
-                                        int delta = result.shiftLeft;
-                                        if (delta != 0) {
-                                            int newSel = Math.max(editorCursor.getLeft() - delta, 0);
-                                            var charPosition = editorCursor.getIndexer().getCharPosition(newSel);
-                                            editor.setSelection(charPosition.line, charPosition.column);
-                                        }
-                                        consumed = true;
-                                    } catch (Exception ex) {
-                                        Log.w(TAG, "Error occurred while calling Language's NewlineHandler", ex);
-                                    }
-                                    break;
-                                }
-                            }
-                        }
-                        if (!consumed) {
-                            editor.commitText(lineSeparator, true);
-                        }
-                    }
-                    editor.notifyIMEExternalCursorChange();
-                }
-                return e.result(true);
+                return handleEnterKeyEvent(editorKeyEvent, keybindingEvent, isShiftPressed, isAltPressed, isCtrlPressed);
             }
             case KeyEvent.KEYCODE_DPAD_DOWN:
                 editor.moveSelectionDown();
-                return e.result(true);
+                return editorKeyEvent.result(true);
             case KeyEvent.KEYCODE_DPAD_UP:
                 editor.moveSelectionUp();
-                return e.result(true);
+                return editorKeyEvent.result(true);
             case KeyEvent.KEYCODE_DPAD_LEFT:
                 editor.moveSelectionLeft();
-                return e.result(true);
+                return editorKeyEvent.result(true);
             case KeyEvent.KEYCODE_DPAD_RIGHT:
                 editor.moveSelectionRight();
-                return e.result(true);
+                return editorKeyEvent.result(true);
             case KeyEvent.KEYCODE_MOVE_END:
                 editor.moveSelectionEnd();
-                return e.result(true);
+                return editorKeyEvent.result(true);
             case KeyEvent.KEYCODE_MOVE_HOME:
                 editor.moveSelectionHome();
-                return e.result(true);
+                return editorKeyEvent.result(true);
             case KeyEvent.KEYCODE_PAGE_DOWN:
                 editor.movePageDown();
-                return e.result(true);
+                return editorKeyEvent.result(true);
             case KeyEvent.KEYCODE_PAGE_UP:
                 editor.movePageUp();
-                return e.result(true);
+                return editorKeyEvent.result(true);
             case KeyEvent.KEYCODE_TAB:
                 if (editor.isEditable()) {
                     if (completionWindow.isShowing()) {
@@ -271,121 +232,227 @@ class EditorKeyEventHandler {
                         editor.commitTab();
                     }
                 }
-                return e.result(true);
+                return editorKeyEvent.result(true);
             case KeyEvent.KEYCODE_PASTE:
                 if (editor.isEditable()) {
                     editor.pasteText();
                 }
-                return e.result(true);
+                return editorKeyEvent.result(true);
             case KeyEvent.KEYCODE_COPY:
                 editor.copyText();
-                return e.result(true);
+                return editorKeyEvent.result(true);
             case KeyEvent.KEYCODE_SPACE:
                 if (editor.isEditable()) {
                     editor.commitText(" ");
                     editor.notifyIMEExternalCursorChange();
                 }
-                return e.result(true);
+                return editorKeyEvent.result(true);
             case KeyEvent.KEYCODE_ESCAPE:
                 if (editorCursor.isSelected()) {
                     final var newPosition = editor.getProps().positionOfCursorWhenExitSelecting ? editorCursor.right() : editorCursor.left();
                     editor.setSelection(newPosition.line, newPosition.column, true);
                 }
-                return e.result(true);
+                return editorKeyEvent.result(true);
             default:
                 if (event.isCtrlPressed() && !event.isAltPressed()) {
-                    switch (keyCode) {
-                        case KeyEvent.KEYCODE_V:
-                            if (editor.isEditable()) {
-                                editor.pasteText();
-                            }
-                            return keybindingEvent.result(true) || e.result(true);
-                        case KeyEvent.KEYCODE_C:
-                            editor.copyText();
-                            return keybindingEvent.result(true) || e.result(true);
-                        case KeyEvent.KEYCODE_X:
-                            if (editor.isEditable()) {
-                                editor.cutText();
-                            } else {
-                                editor.copyText();
-                            }
-                            return keybindingEvent.result(true) || e.result(true);
-                        case KeyEvent.KEYCODE_A:
-                            editor.selectAll();
-                            return keybindingEvent.result(true) || e.result(true);
-                        case KeyEvent.KEYCODE_Z:
-                            if (editor.isEditable()) {
-                                editor.undo();
-                            }
-                            return keybindingEvent.result(true) || e.result(true);
-                        case KeyEvent.KEYCODE_Y:
-                            if (editor.isEditable()) {
-                                editor.redo();
-                            }
-                            return keybindingEvent.result(true) || e.result(true);
-                        case KeyEvent.KEYCODE_D:
-                            if (editor.isEditable()) {
-                                editor.duplicateLine();
-                            }
-                            return keybindingEvent.result(true) || e.result(true);
-                        case KeyEvent.KEYCODE_W:
-                            editor.selectCurrentWord();
-                            return keybindingEvent.result(true) || e.result(true);
-                        case KeyEvent.KEYCODE_J:
-                            if (!isShiftPressed || editorCursor.isSelected()) {
-                                // TODO If the cursor is selected, then the selected lines must be joined.
-                                return keybindingEvent.result(false) || e.result(false);
-                            }
+                    return handleCtrlKeyBinding(editorKeyEvent, keybindingEvent, keyCode, isShiftPressed);
+                }
 
-                            final var line = editorCursor.getLeftLine();
-                            editor.setSelection(line, editorText.getColumnCount(line));
-                            connection.deleteSurroundingText(0, 1);
-                            editor.ensureSelectionVisible();
-                            return keybindingEvent.result(true) || e.result(true);
-                    }
-                } else if (!event.isCtrlPressed() && !event.isAltPressed()) {
-                    if (event.isPrintingKey() && editor.isEditable()) {
-                        String text = new String(Character.toChars(event.getUnicodeChar(event.getMetaState())));
-                        SymbolPairMatch.Replacement replacement = null;
-                        if (text.length() == 1 && editor.getProps().symbolPairAutoCompletion) {
-                            replacement = editor.languageSymbolPairs.getCompletion(text.charAt(0));
-                        }
-                        if (replacement == null || replacement == SymbolPairMatch.Replacement.NO_REPLACEMENT
-                                || (replacement.shouldNotDoReplace(editorText) && replacement.notHasAutoSurroundPair())) {
-                            editor.commitText(text);
-                            editor.notifyIMEExternalCursorChange();
-                        } else {
-                            String[] autoSurroundPair;
-                            if (editorCursor.isSelected() && (autoSurroundPair = replacement.getAutoSurroundPair()) != null) {
-                                editorText.beginBatchEdit();
-                                //insert left
-                                editorText.insert(editorCursor.getLeftLine(), editorCursor.getLeftColumn(), autoSurroundPair[0]);
-                                //insert right
-                                editorText.insert(editorCursor.getRightLine(), editorCursor.getRightColumn(), autoSurroundPair[1]);
-                                editorText.endBatchEdit();
-                                //cancel selected
-                                editor.setSelection(editorCursor.getLeftLine(), editorCursor.getLeftColumn() + autoSurroundPair[0].length() - 1);
-
-                                editor.notifyIMEExternalCursorChange();
-                            } else {
-                                editor.commitText(replacement.text);
-                                int delta = (replacement.text.length() - replacement.selection);
-                                if (delta != 0) {
-                                    int newSel = Math.max(editorCursor.getLeft() - delta, 0);
-                                    CharPosition charPosition = editorCursor.getIndexer().getCharPosition(newSel);
-                                    editor.setSelection(charPosition.line, charPosition.column);
-                                    editor.notifyIMEExternalCursorChange();
-                                }
-                            }
-
-                        }
-                    } else {
-                        return editor.onSuperKeyDown(keyCode, event);
-                    }
-                    return e.result(true);
+                if (!event.isCtrlPressed() && !event.isAltPressed()) {
+                    return handlePrintingKey(event, editorKeyEvent, keyCode);
                 }
         }
-        return e.result(editor.onSuperKeyDown(keyCode, event));
+        return null;
+    }
+
+    @NonNull
+    private Boolean handlePrintingKey(
+            KeyEvent event,
+            EditorKeyEvent editorKeyEvent,
+            int keyCode) {
+        final var editorText = this.editor.getText();
+        final var editorCursor = this.editor.getCursor();
+        if (event.isPrintingKey() && editor.isEditable()) {
+            String text = new String(Character.toChars(event.getUnicodeChar(event.getMetaState())));
+            SymbolPairMatch.Replacement replacement = null;
+            if (text.length() == 1 && editor.getProps().symbolPairAutoCompletion) {
+                replacement = editor.languageSymbolPairs.getCompletion(text.charAt(0));
+            }
+            if (replacement == null || replacement == SymbolPairMatch.Replacement.NO_REPLACEMENT
+                    || (replacement.shouldNotDoReplace(editorText) && replacement.notHasAutoSurroundPair())) {
+                editor.commitText(text);
+                editor.notifyIMEExternalCursorChange();
+            } else {
+                String[] autoSurroundPair;
+                if (editorCursor.isSelected() && (autoSurroundPair = replacement.getAutoSurroundPair()) != null) {
+                    editorText.beginBatchEdit();
+                    //insert left
+                    editorText.insert(editorCursor.getLeftLine(), editorCursor.getLeftColumn(), autoSurroundPair[0]);
+                    //insert right
+                    editorText.insert(editorCursor.getRightLine(), editorCursor.getRightColumn(), autoSurroundPair[1]);
+                    editorText.endBatchEdit();
+                    //cancel selected
+                    editor.setSelection(editorCursor.getLeftLine(), editorCursor.getLeftColumn() + autoSurroundPair[0].length() - 1);
+
+                    editor.notifyIMEExternalCursorChange();
+                } else {
+                    editor.commitText(replacement.text);
+                    int delta = (replacement.text.length() - replacement.selection);
+                    if (delta != 0) {
+                        int newSel = Math.max(editorCursor.getLeft() - delta, 0);
+                        CharPosition charPosition = editorCursor.getIndexer().getCharPosition(newSel);
+                        editor.setSelection(charPosition.line, charPosition.column);
+                        editor.notifyIMEExternalCursorChange();
+                    }
+                }
+
+            }
+        } else {
+            return editor.onSuperKeyDown(keyCode, event);
+        }
+        return editorKeyEvent.result(true);
+    }
+
+    @Nullable
+    private Boolean handleCtrlKeyBinding(
+            EditorKeyEvent e,
+            KeyBindingEvent keybindingEvent,
+            int keyCode,
+            boolean isShiftPressed) {
+        final var connection = this.editor.inputConnection;
+        final var editorText = this.editor.getText();
+        final var editorCursor = this.editor.getCursor();
+        switch (keyCode) {
+            case KeyEvent.KEYCODE_V:
+                if (editor.isEditable()) {
+                    editor.pasteText();
+                }
+                return keybindingEvent.result(true) || e.result(true);
+            case KeyEvent.KEYCODE_C:
+                editor.copyText();
+                return keybindingEvent.result(true) || e.result(true);
+            case KeyEvent.KEYCODE_X:
+                if (editor.isEditable()) {
+                    editor.cutText();
+                } else {
+                    editor.copyText();
+                }
+                return keybindingEvent.result(true) || e.result(true);
+            case KeyEvent.KEYCODE_A:
+                editor.selectAll();
+                return keybindingEvent.result(true) || e.result(true);
+            case KeyEvent.KEYCODE_Z:
+                if (editor.isEditable()) {
+                    editor.undo();
+                }
+                return keybindingEvent.result(true) || e.result(true);
+            case KeyEvent.KEYCODE_Y:
+                if (editor.isEditable()) {
+                    editor.redo();
+                }
+                return keybindingEvent.result(true) || e.result(true);
+            case KeyEvent.KEYCODE_D:
+                if (editor.isEditable()) {
+                    editor.duplicateLine();
+                }
+                return keybindingEvent.result(true) || e.result(true);
+            case KeyEvent.KEYCODE_W:
+                editor.selectCurrentWord();
+                return keybindingEvent.result(true) || e.result(true);
+            case KeyEvent.KEYCODE_J:
+                if (!isShiftPressed || editorCursor.isSelected()) {
+                    // TODO If the cursor is selected, then the selected lines must be joined.
+                    return keybindingEvent.result(false) || e.result(false);
+                }
+
+                final var line = editorCursor.getLeftLine();
+                editor.setSelection(line, editorText.getColumnCount(line));
+                connection.deleteSurroundingText(0, 1);
+                editor.ensureSelectionVisible();
+                return keybindingEvent.result(true) || e.result(true);
+        }
+        return null;
+    }
+
+    @NonNull
+    private Boolean handleEnterKeyEvent(
+            EditorKeyEvent editorKeyEvent,
+            KeyBindingEvent keybindingEvent,
+            boolean isShiftPressed,
+            boolean isAltPressed,
+            boolean isCtrlPressed) {
+        final var editor = this.editor;
+        final var editorCursor = editor.getCursor();
+        final var editorText = editor.getText();
+        final var completionWindow = editor.getComponent(EditorAutoCompletion.class);
+        if (editor.isEditable()) {
+            var lineSeparator = editor.getLineSeparator().getContent();
+            final var editorLanguage = editor.getEditorLanguage();
+            if (completionWindow.isShowing() && completionWindow.select()) {
+                return true;
+            }
+
+            if (isShiftPressed && !isAltPressed && !isCtrlPressed) {
+                // Shift + Enter
+                return startNewLIne(editor, editorCursor, editorText, editorKeyEvent, keybindingEvent);
+            }
+
+            if (isCtrlPressed && !isShiftPressed) {
+                if (isAltPressed) {
+                    // Ctrl + Alt + Enter
+                    var line = editorCursor.left().line;
+                    if (line == 0) {
+                        editorText.insert(0, 0, lineSeparator);
+                        editor.setSelection(0, 0);
+                        editor.ensureSelectionVisible();
+                        return keybindingEvent.result(true) || editorKeyEvent.result(true);
+                    } else {
+                        line--;
+                        editor.setSelection(line, editorText.getColumnCount(line));
+                        return startNewLIne(editor, editorCursor, editorText, editorKeyEvent, keybindingEvent);
+                    }
+                }
+
+                // Ctrl + Enter
+                final var left = editorCursor.left().fromThis();
+                editor.commitText(lineSeparator);
+                editor.setSelection(left.line, left.column);
+                editor.ensureSelectionVisible();
+                return keybindingEvent.result(true) || editorKeyEvent.result(true);
+            }
+
+            NewlineHandler[] handlers = editorLanguage.getNewlineHandlers();
+            if (handlers == null || editorCursor.isSelected()) {
+                editor.commitText(lineSeparator, true);
+            } else {
+                boolean consumed = false;
+                for (NewlineHandler handler : handlers) {
+                    if (handler != null) {
+                        if (handler.matchesRequirement(editorText, editorCursor.left(), editor.getStyles())) {
+                            try {
+                                var result = handler.handleNewline(editorText, editorCursor.left(), editor.getStyles(), editor.getTabWidth());
+                                editor.commitText(result.text, false);
+                                int delta = result.shiftLeft;
+                                if (delta != 0) {
+                                    int newSel = Math.max(editorCursor.getLeft() - delta, 0);
+                                    var charPosition = editorCursor.getIndexer().getCharPosition(newSel);
+                                    editor.setSelection(charPosition.line, charPosition.column);
+                                }
+                                consumed = true;
+                            } catch (Exception ex) {
+                                Log.w(TAG, "Error occurred while calling Language's NewlineHandler", ex);
+                            }
+                            break;
+                        }
+                    }
+                }
+                if (!consumed) {
+                    editor.commitText(lineSeparator, true);
+                }
+            }
+            editor.notifyIMEExternalCursorChange();
+        }
+        return editorKeyEvent.result(true);
     }
 
     private boolean startNewLIne(CodeEditor editor, Cursor editorCursor, Content editorText, EditorKeyEvent e, KeyBindingEvent keybindingEvent) {

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/EditorKeyEventHandler.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/EditorKeyEventHandler.java
@@ -217,12 +217,23 @@ class EditorKeyEventHandler {
                     final var dy = editor.getOffsetY() + editor.getRowHeight() > editor.getScrollMaxY()
                             ? editor.getScrollMaxY() - editor.getOffsetY()
                             : editor.getRowHeight();
-                    editor.getScroller().startScroll(editor.getOffsetX(), editor.getOffsetY(), 0, dy);
+                    editor.getScroller().startScroll(editor.getOffsetX(), editor.getOffsetY(), 0, dy, 0);
                     return editorKeyEvent.result(true);
                 }
                 editor.moveSelectionDown();
                 return editorKeyEvent.result(true);
             case KeyEvent.KEYCODE_DPAD_UP:
+                if (isCtrlPressed) {
+                    if (editor.getOffsetY() == 0) {
+                        return editorKeyEvent.result(true);
+                    }
+                    var dy = -editor.getRowHeight();
+                    if (editor.getOffsetY() - editor.getRowHeight() < 0) {
+                        dy = -editor.getOffsetY();
+                    }
+                    editor.getScroller().startScroll(editor.getOffsetX(), editor.getOffsetY(), 0, dy, 0);
+                    return editorKeyEvent.result(true);
+                }
                 editor.moveSelectionUp();
                 return editorKeyEvent.result(true);
             case KeyEvent.KEYCODE_DPAD_LEFT:

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/EditorKeyEventHandler.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/EditorKeyEventHandler.java
@@ -197,8 +197,12 @@ class EditorKeyEventHandler {
                 return handleEnterKeyEvent(editorKeyEvent, keybindingEvent, isShiftPressed, isAltPressed, isCtrlPressed);
             }
             case KeyEvent.KEYCODE_DPAD_DOWN:
-                editor.moveSelectionDown();
-                return editorKeyEvent.result(true);
+                if (isCtrlPressed) {
+                    editor.getScroller().startScroll(editor.getOffsetX(), editor.getOffsetY(), 0, editor.getRowHeight());
+                    return editorKeyEvent.result(true);
+                }
+            editor.moveSelectionDown();
+            return editorKeyEvent.result(true);
             case KeyEvent.KEYCODE_DPAD_UP:
                 editor.moveSelectionUp();
                 return editorKeyEvent.result(true);

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/EditorKeyEventHandler.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/EditorKeyEventHandler.java
@@ -212,6 +212,12 @@ class EditorKeyEventHandler {
                         editorText.delete(right.line, editorText.getColumnCount(right.line), right.line + 1, next.length());
                         editorText.insert(left.line, 0, next.concat(editor.getLineSeparator().getContent()));
                         editorText.endBatchEdit();
+
+                        // Update selection
+                        if (left.index != right.index) {
+                            editor.setSelectionRegion(left.line + 1, left.column, right.line + 1, right.column);
+                        }
+
                         return editorKeyEvent.result(true);
                     }
                     final var dy = editor.getOffsetY() + editor.getRowHeight() > editor.getScrollMaxY()
@@ -238,6 +244,12 @@ class EditorKeyEventHandler {
                         editorText.delete(left.line - 1, 0, left.line, 0);
                         editorText.insert(right.line - 1, editorText.getColumnCount(right.line - 1), editor.getLineSeparator().getContent().concat(prev));
                         editorText.endBatchEdit();
+
+                        // Update selection
+                        if (left.index != right.index) {
+                            editor.setSelectionRegion(left.line - 1, left.column, right.line + 1, right.column);
+                        }
+
                         return editorKeyEvent.result(true);
                     }
                     if (editor.getOffsetY() == 0) {

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/EditorKeyEventHandler.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/EditorKeyEventHandler.java
@@ -87,6 +87,10 @@ class EditorKeyEventHandler {
 
         // Other key combinations
         return keyCode == KeyEvent.KEYCODE_ENTER
+                || keyCode == KeyEvent.KEYCODE_DPAD_UP
+                || keyCode == KeyEvent.KEYCODE_DPAD_DOWN
+                || keyCode == KeyEvent.KEYCODE_DPAD_LEFT
+                || keyCode == KeyEvent.KEYCODE_DPAD_RIGHT
                 || keyCode == KeyEvent.KEYCODE_MOVE_HOME
                 || keyCode == KeyEvent.KEYCODE_MOVE_END;
     }

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/EditorKeyEventHandler.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/EditorKeyEventHandler.java
@@ -220,6 +220,8 @@ class EditorKeyEventHandler {
                         // Update selection
                         if (left.index != right.index) {
                             editor.setSelectionRegion(left.line + 1, left.column, right.line + 1, right.column);
+                        } else {
+                            editor.setSelection(left.line + 1, left.column);
                         }
 
                         return editorKeyEvent.result(true);
@@ -252,6 +254,8 @@ class EditorKeyEventHandler {
                         // Update selection
                         if (left.index != right.index) {
                             editor.setSelectionRegion(left.line - 1, left.column, right.line + 1, right.column);
+                        } else {
+                            editor.setSelection(left.line - 1, left.column);
                         }
 
                         return editorKeyEvent.result(true);

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/EditorKeyEventHandler.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/EditorKeyEventHandler.java
@@ -214,11 +214,14 @@ class EditorKeyEventHandler {
                         editorText.endBatchEdit();
                         return editorKeyEvent.result(true);
                     }
-                    editor.getScroller().startScroll(editor.getOffsetX(), editor.getOffsetY(), 0, editor.getRowHeight());
+                    final var dy = editor.getOffsetY() + editor.getRowHeight() > editor.getScrollMaxY()
+                            ? editor.getScrollMaxY() - editor.getOffsetY()
+                            : editor.getRowHeight();
+                    editor.getScroller().startScroll(editor.getOffsetX(), editor.getOffsetY(), 0, dy);
                     return editorKeyEvent.result(true);
                 }
-            editor.moveSelectionDown();
-            return editorKeyEvent.result(true);
+                editor.moveSelectionDown();
+                return editorKeyEvent.result(true);
             case KeyEvent.KEYCODE_DPAD_UP:
                 editor.moveSelectionUp();
                 return editorKeyEvent.result(true);

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/EditorTouchEventHandler.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/EditorTouchEventHandler.java
@@ -408,10 +408,12 @@ public final class EditorTouchEventHandler implements GestureDetector.OnGestureL
         }
         switch (selHandleType) {
             case SelectionHandle.LEFT:
+                editor.selectionAnchor = editor.getCursor().right();
                 this.leftHandle.applyPosition(e);
                 scrollIfThumbReachesEdge(e);
                 return true;
             case SelectionHandle.RIGHT:
+                editor.selectionAnchor = editor.getCursor().left();
                 this.rightHandle.applyPosition(e);
                 scrollIfThumbReachesEdge(e);
                 return true;

--- a/keybindings.md
+++ b/keybindings.md
@@ -1,0 +1,30 @@
+## Key bindings
+
+The following key bindings are currently supported by the editor :
+
+| Keybinding             | Description                                                                                                                                |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `Ctrl + A`             | Select all.                                                                                                                                |
+| `Ctrl + X`             | If no content is selected, cuts the current line. Else, performs the usual cut operation.                                                  |
+| `Ctrl + C`             | If no content is selected, selects and copies the current line. Else, performs the usual copy operation.                                   |
+| `Ctrl + V`             | The usual paste action.                                                                                                                    |
+| `Ctrl + U`             | Undo the last action.                                                                                                                      |
+| `Ctrl + R`             | Redo the last action.                                                                                                                      |
+| `Ctrl + D`             | If content is selected, duplicates the selected content else duplicates the current line.                                                  |
+| `Ctrl + W`             | Selects the word at the left selection handle.                                                                                             |
+| `Ctrl + Left`          | Move to word start. If the cursor is already at the current word's start, moves the cursor to previous word's start, skipping whitespaces. |
+| `Ctrl + Right`         | Move to word end. If the cursor is already at the current word's end, moves the cursor to next word's end, skipping whitespaces.           |
+| `Ctrl + Up`            | Scroll up by one row.                                                                                                                      |
+| `Ctrl + Down`          | Scroll down by one row.                                                                                                                    |
+| `Ctrl + Home`          | Moves the cursor to the beginning of content. If in selection mode, sets the selection from beginning of content to the selection anchor.  |
+| `Ctrl + End`           | Moves the cursor to the end of content. If in selection mode, sets the selection from the selection anchor to the end of content.          |
+| `Ctrl + Enter`         | Split line. If content is selected, deletes the selected content then splits the line.                                                     |
+| `Ctrl + Shift + Left`  | Same as `Ctrl+Left`, but starts or updates the selection.                                                                                  |
+| `Ctrl + Shift + Right` | Same as `Ctrl+Right`, but starts or updates the selection.                                                                                 |
+| `Ctrl + Shift + Up`    | Moves the current line (or all selected lines) up by one line.                                                                             |
+| `Ctrl + Shift + Down`  | Moves the current line (or all selected lines) down by one line.                                                                           |
+| `Ctrl + Shift + Home`  | Same as `Ctrl+Home`, but starts or updates the selection.                                                                                  |
+| `Ctrl + Shift + End`   | Same as `Ctrl+End`, but starts or updates the selection.                                                                                   |
+| `Ctrl + Alt + Enter`   | Start a new line before current line.                                                                                                      |
+| `Ctrl + Shift + J`     | Join current line and next line.                                                                                                           |
+| `Shift + Enter`        | Start a new line.                                                                                                                          |


### PR DESCRIPTION
This PR adds support for the following keybindings :
- `Ctrl+Left` : Move to word start. If the cursor is already at the current word's start, moves the cursor to previous word's start, skipping whitespaces.
- `Ctrl+Right` : Move to word end. If the cursor is already at the current word's end, moves the cursor to next word's end, skipping whitespaces.
- `Ctrl+Up` : Scroll up by one row.
- `Ctrl+Down` : Scroll down by one row.
- `Ctrl+Shift+Left` : Same as `Ctrl+Left`, but starts or updates the selection.
- `Ctrl+Shift+Right` : Same as `Ctrl+Right`, but starts or updates the selection.
- `Ctrl+Shift+Up` : Moves the current line (or all selected lines) up by one line.
- `Ctrl+Shift+Down` : Moves the current line (or all selected lines) down by one line.
- `Ctrl+Home` : Moves the cursor to the beginning of content. If in selection mode, sets the selection from beginning of content to the selection anchor.
- `Ctrl+End` : Moves the cursor to the end of content. If in selection mode, sets the selection from the selection anchor to the end of content.
- `Ctrl+Shift+Home` : Same as `Ctrl+Home`, but starts or updates the selection.
- `Ctrl+Shift+End` : Same as `Ctrl+End`, but starts or updates the selection.

The selection anchor is currently not updated when the selection is started with a double tap or when the selection handles are moved. Due to this, selection started with a touch event cannot be updated with key event. This PR includes the following fix for this issue :
- In case of double tap selection, the selection anchor is set to the left selection handle so the right selection handle could be moved with key events.
- When the selection handles are moved with touch event, the selection anchor is set to the other selection handle. So for example, if the left selection handle is moved, the selection anchor is set to the right selection handle.