### PR TITLE
Removed hardcoded '\t' in CodeEditor.commitTab() and made EditorKeyEvent interceptable

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="18" />
+    <bytecodeTargetLevel target="11" />
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -24,5 +24,5 @@
     <option name="OUTPUT_DIRECTORY" value="D:/Javadoc" />
     <option name="OPTION_INCLUDE_LIBS" value="true" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_18_PREVIEW" project-jdk-name="11" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="11" project-jdk-type="JavaSDK" />
 </project>

--- a/editor/src/main/java/io/github/rosemoe/sora/event/EditorKeyEvent.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/event/EditorKeyEvent.java
@@ -55,6 +55,11 @@ public class EditorKeyEvent extends ResultedEvent<Boolean> {
         altPressed = getEditor().getKeyMetaStates().isAltPressed();
     }
 
+    @Override
+    public boolean canIntercept() {
+        return true;
+    }
+
     public int getAction() {
         return src.getAction();
     }

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/CodeEditor.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/CodeEditor.java
@@ -131,6 +131,7 @@ import io.github.rosemoe.sora.widget.style.SelectionHandleStyle;
 import io.github.rosemoe.sora.widget.style.builtin.HandleStyleDrop;
 import io.github.rosemoe.sora.widget.style.builtin.HandleStyleSideDrop;
 import io.github.rosemoe.sora.widget.style.builtin.MoveCursorAnimator;
+import kotlin.text.StringsKt;
 
 /**
  * CodeEditor is an editor that can highlight text regions by doing basic syntax analyzing
@@ -1611,10 +1612,23 @@ public class CodeEditor extends View implements ContentListener, Formatter.Forma
     /**
      * Commit a tab to cursor
      */
-    void commitTab() {
+    protected void commitTab() {
         if (inputConnection != null && isEditable()) {
-            inputConnection.commitTextInternal("\t", true);
+            inputConnection.commitTextInternal(createTabString(), true);
         }
+    }
+
+    /**
+     * Creates the string to insert when <code>KEYCODE_TAB</code> key event is received from the IME.
+     *
+     * @return The string to insert for tab character.
+     */
+    protected String createTabString() {
+        final var language = getEditorLanguage();
+        if (language.useTab()) {
+            return "\t";
+        }
+        return StringsKt.repeat(" ", getTabWidth());
     }
 
     protected void updateCompletionWindowPosition() {

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/component/EditorAutoCompletion.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/component/EditorAutoCompletion.java
@@ -59,8 +59,8 @@ public class EditorAutoCompletion extends EditorPopupWindow implements EditorBui
     protected CompletionThread completionThread;
     protected CompletionPublisher publisher;
     protected WeakReference<List<CompletionItem>> lastAttachedItems;
-    private int currentSelection = -1;
-    private EditorCompletionAdapter adapter;
+    protected int currentSelection = -1;
+    protected EditorCompletionAdapter adapter;
     private CompletionLayout layout;
     private long requestShow = 0;
     private long requestHide = -1;


### PR DESCRIPTION
This PR fixes the following issues : 
- As stated in AndroidIDEOfficial/AndroidIDE#562, the editor currently does not make use of `Language.useTab()` when `KEYCODE_TAB` key event is received from the IME. Instead, it has the tab character hardcoded in it.
- Currently, it is not possible to intercept key events in editor because both, `EditorKeyEvent` and `KeyBindingEvent` does not implement the `canIntercept()` method.