### PR TITLE
fix multi thread error in OnigRegExp, etc

### DIFF
--- a/editor/src/main/java/io/github/rosemoe/sora/widget/CodeEditor.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/CodeEditor.java
@@ -3266,6 +3266,7 @@ public class CodeEditor extends View implements ContentListener, Formatter.Forma
      * @param makeRightVisible Whether to make right cursor visible
      */
     public void setSelectionRegion(int lineLeft, int columnLeft, int lineRight, int columnRight, boolean makeRightVisible, int cause) {
+        requestFocus();
         int start = getText().getCharIndex(lineLeft, columnLeft);
         int end = getText().getCharIndex(lineRight, columnRight);
         if (start == end) {
@@ -3518,7 +3519,6 @@ public class CodeEditor extends View implements ContentListener, Formatter.Forma
         final var range = getWordRange(line, column);
         final var start = range.getStart();
         final var end = range.getEnd();
-        requestFocusFromTouch();
         setSelectionRegion(start.line, start.column, end.line, end.column, SelectionChangeEvent.CAUSE_LONG_PRESS);
         selectionAnchor = getCursor().left();
     }

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/DirectAccessProps.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/DirectAccessProps.java
@@ -299,4 +299,12 @@ public class DirectAccessProps implements Serializable {
     @InvalidateRequired
     public int hardwrapColumn = 0;
 
+    /**
+     * Select words even if some texts are already selected when the editor is
+     * long-pressed.
+     * If true, new text under the new long-press will be selected. Otherwise, the old text is kept
+     * selected.
+     */
+    public boolean reselectOnLongPress = true;
+
 }

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/EditorTouchEventHandler.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/EditorTouchEventHandler.java
@@ -585,7 +585,7 @@ public final class EditorTouchEventHandler implements GestureDetector.OnGestureL
         if ((editor.dispatchEvent(new LongPressEvent(editor, editor.getText().getIndexer().getCharPosition(line, column), e)) & InterceptTarget.TARGET_EDITOR) != 0) {
             return;
         }
-        if (e.getPointerCount() != 1) {
+        if ((!editor.getProps().reselectOnLongPress && editor.getCursor().isSelected()) || e.getPointerCount() != 1) {
             return;
         }
         editor.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS);

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/EditorTouchEventHandler.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/EditorTouchEventHandler.java
@@ -585,7 +585,7 @@ public final class EditorTouchEventHandler implements GestureDetector.OnGestureL
         if ((editor.dispatchEvent(new LongPressEvent(editor, editor.getText().getIndexer().getCharPosition(line, column), e)) & InterceptTarget.TARGET_EDITOR) != 0) {
             return;
         }
-        if (editor.getCursor().isSelected() || e.getPointerCount() != 1) {
+        if (e.getPointerCount() != 1) {
             return;
         }
         editor.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS);

--- a/language-textmate/src/main/java/org/eclipse/tm4e/core/internal/oniguruma/OnigRegExp.java
+++ b/language-textmate/src/main/java/org/eclipse/tm4e/core/internal/oniguruma/OnigRegExp.java
@@ -62,7 +62,7 @@ public final class OnigRegExp {
 	}
 
 	@Nullable
-	public OnigResult search(final OnigString str, final int startPosition) {
+	public synchronized OnigResult search(final OnigString str, final int startPosition) {
 		if (hasGAnchor) {
 			// Should not use caching, because the regular expression
 			// targets the current search position (\G)
@@ -83,7 +83,7 @@ public final class OnigRegExp {
 	}
 
 	@Nullable
-	private OnigResult search(final byte[] data, final int startPosition, final int end) {
+	private synchronized OnigResult search(final byte[] data, final int startPosition, final int end) {
 		final Matcher matcher = regex.matcher(data);
 		final int status = matcher.search(startPosition, end, Option.DEFAULT);
 		if (status != Matcher.FAILED) {


### PR DESCRIPTION
1. 当有多个 editor 实例时 OnigRegExp 类里面的缓存会被多线程访问，会导致崩溃 
2. 如果当前已经选中了文字显示了TextAction，再长按别处，可以切换选中。
3. requestFocusFromTouch 会导致 弹出的 TextAction 不符合预期的获取到焦点，按钮是选中状态；设置selection 时自动获取焦点。