### PR TITLE
fix: An exception on TextMateNewlineHandler

### DIFF
--- a/language-textmate/src/main/java/io/github/rosemoe/sora/langs/textmate/TextMateNewlineHandler.java
+++ b/language-textmate/src/main/java/io/github/rosemoe/sora/langs/textmate/TextMateNewlineHandler.java
@@ -208,7 +208,7 @@ public class TextMateNewlineHandler implements NewlineHandler {
         if (indentRulesSupport.shouldDecrease(afterEnterText)) {
             // afterEnterIndent = indentConverter.unshiftIndent(afterEnterIndent);
 
-            afterEnterIndent = beforeEnterIndent.substring(0, beforeEnterIndent.length() - indent.length());
+            afterEnterIndent = beforeEnterIndent.substring(0, Math.max(Math.max(0, beforeEnterIndent.length() - 1), beforeEnterIndent.length() - indent.length() /*- 1*/));
         }
 
         return new Pair<>(beforeEnterIndent, afterEnterIndent);


### PR DESCRIPTION
See error log:

```
Crash at 1672804988527(timestamp) in thread named 'main'
Local date and time:2023年1月4日 12:03:08
BOARD=oppo6765_19181
ACTIVE_CODENAMES=[]
CPU_ABI2=
HOST=Ubuntu-134-12
versionName=0.20.1-1671792647944
SUPPORTED_64_BIT_ABIS=[arm64-v8a]
CODENAME=REL
CPU_ABI=arm64-v8a
PERMISSIONS_REVIEW_REQUIRED=false
SDK_INT=28
DISPLAY=PDBM00_11_A.30
SUPPORTED_ABIS=[arm64-v8a, armeabi-v7a, armeabi]
FINGERPRINT=OPPO/PDBM00/OP4AED:9/PPR1.180610.011/1641904128:user/release-keys
PRODUCT=PDBM00
ID=PPR1.180610.011
SDK=28
TYPE=user
SERIAL=unknown
DEVICE=OP4AED
RESOURCES_SDK_INT=28
SECURITY_PATCH=2022-01-05
TIME=1641910166000
BASE_OS=OPPO/PDBM00/OP4AED:9/PPR1.180610.011/1636948094:user/release-keys
MODEL=PDBM00
RELEASE=9
MANUFACTURER=OPPO
USER=root
versionCode=72
BRAND=OPPO
SUPPORTED_32_BIT_ABIS=[armeabi-v7a, armeabi]
HARDWARE=mt6765
IS_DEBUGGABLE=false
FIRST_SDK_INT=28
BOOTLOADER=unknown
RADIO=unknown
PREVIEW_SDK_INT=0
UNKNOWN=unknown
IS_EMULATOR=false
TAGS=release-keys
INCREMENTAL=1641910166
java.lang.StringIndexOutOfBoundsException: String index out of range: -4
	at java.lang.String.substring(String.java:2036)
	at io.github.rosemoe.sora.langs.textmate.TextMateNewlineHandler.getIndentForEnter(TextMateNewlineHandler.java:211)
	at io.github.rosemoe.sora.langs.textmate.TextMateNewlineHandler.matchesRequirement(TextMateNewlineHandler.java:106)
	at io.github.rosemoe.sora.widget.EditorKeyEventHandler.handleEnterKeyEvent(EditorKeyEventHandler.java:589)
	at io.github.rosemoe.sora.widget.EditorKeyEventHandler.handleKeyEvent(EditorKeyEventHandler.java:201)
	at io.github.rosemoe.sora.widget.EditorKeyEventHandler.onKeyDown(EditorKeyEventHandler.java:159)
	at io.github.rosemoe.sora.widget.CodeEditor.onKeyDown(CodeEditor.java:4223)
	at android.view.KeyEvent.dispatch(KeyEvent.java:2719)
	at android.view.View.dispatchKeyEvent(View.java:12641)
	at android.view.ViewGroup.dispatchKeyEvent(ViewGroup.java:1912)
	at android.view.ViewGroup.dispatchKeyEvent(ViewGroup.java:1912)
	at android.view.ViewGroup.dispatchKeyEvent(ViewGroup.java:1912)
	at android.view.ViewGroup.dispatchKeyEvent(ViewGroup.java:1912)
	at android.view.ViewGroup.dispatchKeyEvent(ViewGroup.java:1912)
	at com.android.internal.policy.DecorView.superDispatchKeyEvent(DecorView.java:531)
	at com.android.internal.policy.PhoneWindow.superDispatchKeyEvent(PhoneWindow.java:1884)
	at android.app.Activity.dispatchKeyEvent(Activity.java:3490)
	at androidx.core.app.ComponentActivity.superDispatchKeyEvent(ComponentActivity.java:126)
	at androidx.core.view.KeyEventDispatcher.dispatchKeyEvent(KeyEventDispatcher.java:86)
	at androidx.core.app.ComponentActivity.dispatchKeyEvent(ComponentActivity.java:144)
	at androidx.appcompat.app.AppCompatActivity.dispatchKeyEvent(AppCompatActivity.java:601)
	at androidx.appcompat.view.WindowCallbackWrapper.dispatchKeyEvent(WindowCallbackWrapper.java:60)
	at androidx.appcompat.app.AppCompatDelegateImpl$AppCompatWindowCallback.dispatchKeyEvent(AppCompatDelegateImpl.java:3106)
	at com.android.internal.policy.DecorView.dispatchKeyEvent(DecorView.java:409)
	at android.view.ViewRootImpl$ViewPostImeInputStage.processKeyEvent(ViewRootImpl.java:6019)
	at android.view.ViewRootImpl$ViewPostImeInputStage.onProcess(ViewRootImpl.java:5877)
	at android.view.ViewRootImpl$InputStage.deliver(ViewRootImpl.java:5339)
	at android.view.ViewRootImpl$InputStage.onDeliverToNext(ViewRootImpl.java:5399)
	at android.view.ViewRootImpl$InputStage.forward(ViewRootImpl.java:5358)
	at android.view.ViewRootImpl$AsyncInputStage.forward(ViewRootImpl.java:5525)
	at android.view.ViewRootImpl$InputStage.apply(ViewRootImpl.java:5366)
	at android.view.ViewRootImpl$AsyncInputStage.apply(ViewRootImpl.java:5582)
	at android.view.ViewRootImpl$InputStage.deliver(ViewRootImpl.java:5339)
	at android.view.ViewRootImpl$InputStage.onDeliverToNext(ViewRootImpl.java:5399)
	at android.view.ViewRootImpl$InputStage.forward(ViewRootImpl.java:5358)
	at android.view.ViewRootImpl$InputStage.apply(ViewRootImpl.java:5366)
	at android.view.ViewRootImpl$InputStage.deliver(ViewRootImpl.java:5339)
	at android.view.ViewRootImpl.deliverInputEvent(ViewRootImpl.java:8273)
	at android.view.ViewRootImpl.doProcessInputEvents(ViewRootImpl.java:8242)
	at android.view.ViewRootImpl.enqueueInputEvent(ViewRootImpl.java:8199)
	at android.view.ViewRootImpl$ViewRootHandler.handleMessage(ViewRootImpl.java:5092)
	at android.os.Handler.dispatchMessage(Handler.java:106)
	at android.os.Looper.loop(Looper.java:233)
	at android.app.ActivityThread.main(ActivityThread.java:7225)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:499)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:962)

```

I modified a line of the code to fix this bug. This also means that the module may need more testing to find such problems.