### PR TITLE
Upgrade desugar_jdk_libs to 2.0.3

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ androidx-core-ktx = { module = "androidx.core:core-ktx", version = "1.10.0" }
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version = "1.6.1" }
 androidx-test-junit = { module = "androidx.test.ext:junit", version = "1.1.5" }
 androidx-test-espresso = { module = "androidx.test.espresso:espresso-core", version = "3.5.1" }
-desugar = { module = "com.android.tools:desugar_jdk_libs", version = "1.2.3" }
+desugar = { module = "com.android.tools:desugar_jdk_libs", version = "2.0.3" }
 kotlinx-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version = "1.6.4" }
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
 lifecycle-runtime = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version = "2.6.1"}

--- a/language-textmate/build.gradle.kts
+++ b/language-textmate/build.gradle.kts
@@ -53,6 +53,9 @@ android {
         // Flag to enable support for the new language APIs
         isCoreLibraryDesugaringEnabled = true
     }
+    kotlinOptions {
+        jvmTarget = "11"
+    }
 }
 
 dependencies {


### PR DESCRIPTION
Fixes issues with old APIs (Android < 8).

Closes #416