### PR TITLE
fix: handle null CodeBlock in binarySearchEndBlock

### DIFF
--- a/editor/src/main/java/io/github/rosemoe/sora/lang/styling/CodeBlock.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/lang/styling/CodeBlock.java
@@ -24,8 +24,8 @@
 package io.github.rosemoe.sora.lang.styling;
 
 import androidx.annotation.NonNull;
-
 import java.util.Comparator;
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -43,6 +43,7 @@ public class CodeBlock {
             return res;
         }
     };
+
     public static final Comparator<CodeBlock> COMPARATOR_START = (a, b) -> {
         var res = Integer.compare(a.startLine, b.startLine);
         if (res == 0) {
@@ -51,6 +52,74 @@ public class CodeBlock {
             return res;
         }
     };
+
+    /**
+     * Performs a binary search to find the index of the smallest code block whose end line is
+     * greater than or equal to the specified line.
+     * <p>
+     * This implementation also handles the case where the elements in the list are
+     * <code>null</code>. If a null element is encountered at <code>mid</code>, we look for the
+     * first non-null element either before and after the element and set it as <code>mid</code>.
+     *
+     * @param line   The line number to search for.
+     * @param blocks The list of code blocks to search within.
+     * @return The index of the smallest code block with an end line greater than or equal to the
+     * specified line. If no matching code block is found, -1 is returned.
+     */
+    public static int binarySearchEndBlock(int line, List<CodeBlock> blocks) {
+        if (blocks == null || blocks.isEmpty()) {
+            return -1;
+        }
+
+        int left = 0, right = blocks.size() - 1, mid, row;
+        int max = right;
+
+        while (left <= right) {
+            mid = left + (right - left) / 2;
+            if (mid < 0 || mid > max) {
+                return -1;
+            }
+
+            CodeBlock block = blocks.get(mid);
+            if (block == null) {
+                int nonNullLeft = mid - 1;
+                int nonNullRight = mid + 1;
+
+                while (true) {
+                    if (nonNullLeft < left && nonNullRight > right) {
+                        return -1;
+                    } else if (nonNullLeft >= left && blocks.get(nonNullLeft) != null) {
+                        mid = nonNullLeft;
+                        break;
+                    } else if (nonNullRight <= right && blocks.get(nonNullRight) != null) {
+                        mid = nonNullRight;
+                        break;
+                    }
+                    nonNullLeft--;
+                    nonNullRight++;
+                }
+
+                block = blocks.get(mid);
+            }
+
+            row = block.endLine;
+            if (row > line) {
+                right = mid - 1;
+            } else if (row < line) {
+                left = mid + 1;
+            } else {
+                left = mid;
+                break;
+            }
+        }
+
+        if (left < 0 || left > max) {
+            return -1;
+        }
+
+        return left;
+    }
+
     /**
      * Start line of code block
      */
@@ -79,10 +148,16 @@ public class CodeBlock {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
         CodeBlock codeBlock = (CodeBlock) o;
-        return startLine == codeBlock.startLine && startColumn == codeBlock.startColumn && endLine == codeBlock.endLine && endColumn == codeBlock.endColumn && toBottomOfEndLine == codeBlock.toBottomOfEndLine;
+        return startLine == codeBlock.startLine && startColumn == codeBlock.startColumn &&
+          endLine == codeBlock.endLine && endColumn == codeBlock.endColumn &&
+          toBottomOfEndLine == codeBlock.toBottomOfEndLine;
     }
 
     @Override
@@ -93,6 +168,7 @@ public class CodeBlock {
     @NonNull
     @Override
     public String toString() {
+        //@formatter:off
         return "BlockLine{" +
                 "startLine=" + startLine +
                 ", startColumn=" + startColumn +
@@ -100,5 +176,6 @@ public class CodeBlock {
                 ", endColumn=" + endColumn +
                 ", toBottomOfEndLine=" + toBottomOfEndLine +
                 '}';
+        //@formatter:on
     }
 }

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/CodeEditor.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/CodeEditor.java
@@ -67,16 +67,10 @@ import android.widget.EdgeEffect;
 import android.widget.EditText;
 import android.widget.SearchView;
 import android.widget.Toast;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.Px;
 import androidx.annotation.UiThread;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-
 import io.github.rosemoe.sora.I18nConfig;
 import io.github.rosemoe.sora.R;
 import io.github.rosemoe.sora.annotations.UnsupportedUserUsage;
@@ -142,6 +136,9 @@ import io.github.rosemoe.sora.widget.style.builtin.DefaultLineNumberTip;
 import io.github.rosemoe.sora.widget.style.builtin.HandleStyleDrop;
 import io.github.rosemoe.sora.widget.style.builtin.HandleStyleSideDrop;
 import io.github.rosemoe.sora.widget.style.builtin.MoveCursorAnimator;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 import kotlin.text.StringsKt;
 
 /**
@@ -1511,6 +1508,9 @@ public class CodeEditor extends View implements ContentListener, Formatter.Forma
     private int findCursorBlock(List<CodeBlock> blocks) {
         int line = cursor.getLeftLine();
         int min = binarySearchEndBlock(line, blocks);
+        if (min == -1) {
+            min = 0;
+        }
         int max = blocks.size() - 1;
         int minDis = Integer.MAX_VALUE;
         int found = -1;
@@ -1545,35 +1545,18 @@ public class CodeEditor extends View implements ContentListener, Formatter.Forma
     }
 
     /**
-     * Find the first code block that maybe seen on screen
-     * Because the code blocks is sorted by its end line position
-     * we can use binary search to quicken this process in order to decrease
-     * the time we use on finding
+     * Find the first code block that maybe seen on screen Because the code blocks is sorted by its
+     * end line position we can use binary search to quicken this process in order to decrease the
+     * time we use on finding
      *
      * @param firstVis The first visible line
      * @param blocks   Current code blocks
-     * @return The block we found. It is always a valid index(Unless there is no block)
+     * @return The index of the block we found or <code>-1</code> if no code block is found.
      */
     int binarySearchEndBlock(int firstVis, List<CodeBlock> blocks) {
-        //end > firstVis
-        int left = 0, right = blocks.size() - 1, mid, row;
-        int max = right;
-        while (left <= right) {
-            mid = (left + right) / 2;
-            if (mid < 0) return 0;
-            if (mid > max) return max;
-            row = blocks.get(mid).endLine;
-            if (row > firstVis) {
-                right = mid - 1;
-            } else if (row < firstVis) {
-                left = mid + 1;
-            } else {
-                left = mid;
-                break;
-            }
-        }
-        return Math.max(0, Math.min(left, max));
+        return CodeBlock.binarySearchEndBlock(firstVis, blocks);
     }
+
 
     /**
      * Get spans on the given line

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/EditorRenderer.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/EditorRenderer.java
@@ -1847,6 +1847,9 @@ public class EditorRenderer {
         int invalidCount = 0;
         int maxCount = styles.getSuppressSwitch();
         int mm = editor.binarySearchEndBlock(first, blocks);
+        if (mm == -1) {
+            mm = 0;
+        }
         int cursorIdx = editor.getCurrentCursorBlock();
         for (int curr = mm; curr < blocks.size(); curr++) {
             CodeBlock block = blocks.get(curr);


### PR DESCRIPTION
The `binarySearchEndBlock` method now handles cases where a `null` `CodeBlock` is encountered during the search. The code now adjusts the indices to continue the search until a non-null `CodeBlock` is found. This fix prevents `NullPointerException` when accessing null `CodeBlock`s in the list.

Also, the method now returns -1 if no block is found.

This change should fix AndroidIDEOfficial/AndroidIDE#927 and hopefully AndroidIDEOfficial/AndroidIDE#906.