### PR TITLE
fix: migrate to android-tree-sitter v3.0.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 agp = "8.0.1"
 kotlin = "1.8.20"
 lifecycle = "2.5.1"
-tsBinding = "2.0.0"
+tsBinding = "3.0.0"
 lsp4j = "0.20.1"
 androidxAnnotation = "1.6.0"
 

--- a/language-treesitter/src/main/java/io/github/rosemoe/sora/editor/ts/TsAnalyzeManager.kt
+++ b/language-treesitter/src/main/java/io/github/rosemoe/sora/editor/ts/TsAnalyzeManager.kt
@@ -226,7 +226,7 @@ open class TsAnalyzeManager(val languageSpec: TsLanguageSpec, var theme: TsTheme
         }
 
         fun updateCodeBlocks() {
-            if (languageSpec.blocksQuery.patternCount == 0) {
+            if (languageSpec.blocksQuery.patternCount == 0 || !languageSpec.blocksQuery.isValid) {
                 return
             }
             val blocks = mutableListOf<CodeBlock>()

--- a/language-treesitter/src/main/java/io/github/rosemoe/sora/editor/ts/TsBracketPairs.kt
+++ b/language-treesitter/src/main/java/io/github/rosemoe/sora/editor/ts/TsBracketPairs.kt
@@ -45,7 +45,7 @@ class TsBracketPairs(
     }
 
     override fun getPairedBracketAt(text: Content, index: Int): PairedBracket? {
-        if (languageSpec.bracketsQuery.patternCount > 0) {
+        if (languageSpec.bracketsQuery.patternCount > 0 && languageSpec.bracketsQuery.isValid) {
             TSQueryCursor().use { cursor ->
                 cursor.setByteRange(max(0, index - 1) * 2, index * 2 + 1)
                 cursor.exec(languageSpec.bracketsQuery, tree.rootNode)

--- a/language-treesitter/src/main/java/io/github/rosemoe/sora/editor/ts/TsLanguageSpec.kt
+++ b/language-treesitter/src/main/java/io/github/rosemoe/sora/editor/ts/TsLanguageSpec.kt
@@ -74,7 +74,7 @@ open class TsLanguageSpec(
     /**
      * The actual [TSQuery] object
      */
-    val tsQuery = TSQuery(language, querySource)
+    val tsQuery = TSQuery.create(language, querySource)
 
     /**
      * The first index of highlighting pattern
@@ -107,9 +107,9 @@ open class TsLanguageSpec(
      */
     val localsDefinitionValueIndices = mutableListOf<Int>()
 
-    val blocksQuery = TSQuery(language, codeBlocksScmSource)
+    val blocksQuery = TSQuery.create(language, codeBlocksScmSource)
 
-    val bracketsQuery = TSQuery(language, bracketsScmSource)
+    val bracketsQuery = TSQuery.create(language, bracketsScmSource)
 
     init {
         // Check the queries before access
@@ -120,6 +120,9 @@ open class TsLanguageSpec(
                 if (it > 0xFF.toChar()) {
                     throw IllegalArgumentException("use non-ASCII characters in scm source is unexpected")
                 }
+            }
+            if (!tsQuery.isValid) {
+                throw IllegalArgumentException("Syntax highlights query is invalid")
             }
             if (tsQuery.errorType != TSQueryError.None) {
                 val region = if (tsQuery.errorOffset < highlightScmOffset) "locals" else "highlight"


### PR DESCRIPTION
This PR addresses the breaking change introduced in [android-tree-sitter v3.0.0](https://github.com/AndroidIDEOfficial/android-tree-sitter/releases/tag/v3.0.0).