### PR TITLE
Support for applying completion item background with textmate color schemes

### DIFF
--- a/language-textmate/src/main/java/io/github/rosemoe/sora/langs/textmate/TextMateColorScheme.java
+++ b/language-textmate/src/main/java/io/github/rosemoe/sora/langs/textmate/TextMateColorScheme.java
@@ -167,6 +167,15 @@ public class TextMateColorScheme extends EditorColorScheme implements ThemeRegis
             setColor(TEXT_NORMAL, Color.parseColor(foreground));
         }
 
+        String completionWindowBackground = (String) themeRaw.get("completionWindowBackground");
+        if (completionWindowBackground != null) {
+            setColor(COMPLETION_WND_BACKGROUND, Color.parseColor(completionWindowBackground));
+        }
+
+        String completionWindowBackgroundCurrent = (String) themeRaw.get("completionWindowBackgroundCurrent");
+        if (completionWindowBackgroundCurrent != null) {
+            setColor(COMPLETION_WND_ITEM_CURRENT, Color.parseColor(completionWindowBackgroundCurrent));
+        }
 
         String highlightedDelimetersForeground =
                 (String) themeRaw.get("highlightedDelimetersForeground");


### PR DESCRIPTION
You can now apply the completion item background when using `TextMateColorScheme` by modifying the textmate theme.

Example
```json
{
  "name": "darcula",
  "settings": [
    {
      "settings": {
        "completionWindowBackground": "#1F1A1B",
        "completionWindowBackgroundCurrent": "#1F1A1B"
      }
    }
  ]
}
```