### PR TITLE
feat(editor): indent selected text on TAB key event

### DIFF
--- a/editor/src/main/java/io/github/rosemoe/sora/text/TextUtils.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/text/TextUtils.java
@@ -25,6 +25,8 @@ package io.github.rosemoe.sora.text;
 
 import androidx.annotation.NonNull;
 
+import java.util.Objects;
+
 import io.github.rosemoe.sora.util.IntPair;
 
 /**
@@ -33,25 +35,38 @@ import io.github.rosemoe.sora.util.IntPair;
 public class TextUtils {
 
     /**
+     * Counts the number of whitespaces at the start of the given {@link CharSequence}.
+     *
+     * @param text     The text to count the spaces in.
+     * @return A long packed with the number of spaces and tabs at the start of the line.
+     * Use {@link IntPair#getFirst(long)} to get the number of spaces and {@link IntPair#getSecond(long)}
+     * for the number of tabs.
+     */
+    public static long countLeadingSpacesAndTabs(@NonNull CharSequence text) {
+        Objects.requireNonNull(text);
+
+        int p = 0, spaces = 0, tabs = 0;
+        char c;
+        while (p < text.length() && isWhitespace((c = text.charAt(p)))) {
+            if (c == '\t') {
+                tabs += 1;
+            } else {
+                spaces += 1;
+            }
+            ++p;
+        }
+
+        return IntPair.pack(spaces, tabs);
+    }
+
+    /**
      * Compute leading space count
      *
      * @param tabWidth Tab is considered in {@code tabWidth} spaces
      */
     public static int countLeadingSpaceCount(@NonNull CharSequence text, int tabWidth) {
-        int p = 0, count = 0;
-        while (p < text.length()) {
-            if (isWhitespace(text.charAt(p))) {
-                if (text.charAt(p) == '\t') {
-                    count += tabWidth;
-                } else {
-                    count++;
-                }
-                p++;
-            } else {
-                break;
-            }
-        }
-        return count;
+        final var result = countLeadingSpacesAndTabs(text);
+        return IntPair.getFirst(result) + (tabWidth * IntPair.getSecond(result));
     }
 
     /**
@@ -167,5 +182,4 @@ public class TextUtils {
         }
         return IntPair.pack(leading, trailing);
     }
-
 }

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/CodeEditor.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/CodeEditor.java
@@ -1643,8 +1643,6 @@ public class CodeEditor extends View implements ContentListener, Formatter.Forma
      * not selected.
      */
     public void indentSelection() {
-        // this method is an instance method so that library users can implement
-        // the same behavior with a button (like in the symbol input bar)
 
         final var cursor = getCursor();
         if (!cursor.isSelected()) {
@@ -1660,6 +1658,26 @@ public class CodeEditor extends View implements ContentListener, Formatter.Forma
             text.insert(i, 0, tabString);
         }
         text.endBatchEdit();
+    }
+
+  /**
+   * Removes indentation from the start of the selected lines. If the text is not selected, or if
+   * the start and end selection is on the same line, only the line at the cursor position is
+   * unindented.
+   */
+    public void unindentSelection() {
+      final var cursor = getCursor();
+      final var text = getText();
+
+      text.beginBatchEdit();
+      for (int i = cursor.getLeftLine(); i <= cursor.getRightLine(); i++) {
+          final var line = text.getLineString(i);
+          final var end = Math.min(getTabWidth(), line.length());
+          if (line.substring(0, end).isBlank()) {
+            text.delete(i, 0, i, end);
+          }
+      }
+      text.endBatchEdit();
     }
 
     /**

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/CodeEditor.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/CodeEditor.java
@@ -1650,7 +1650,7 @@ public class CodeEditor extends View implements ContentListener, Formatter.Forma
 
     /**
      * Indents the lines. Does nothing if the <code>onlyIfSelected</code> is <code>true</code> and
-     * the no text is selected.
+     * no text is selected.
      * 
      * @param onlyIfSelected Set to <code>true</code> if lines must be indented only if the text is
      *                      selected.

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/CodeEditor.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/CodeEditor.java
@@ -1639,6 +1639,30 @@ public class CodeEditor extends View implements ContentListener, Formatter.Forma
     }
 
     /**
+     * Inserts indentation string at the start of the selected lines. Does nothing if the text is
+     * not selected.
+     */
+    public void indentSelection() {
+        // this method is an instance method so that library users can implement
+        // the same behavior with a button (like in the symbol input bar)
+
+        final var cursor = getCursor();
+        if (!cursor.isSelected()) {
+            Log.w(LOG_TAG, "indentSelection: text is not selected, ignoring.");
+            return;
+        }
+
+        final var tabString = createTabString();
+
+        final var text = getText();
+        text.beginBatchEdit();
+        for (int i = cursor.getLeftLine(); i <= cursor.getRightLine(); i++) {
+            text.insert(i, 0, tabString);
+        }
+        text.endBatchEdit();
+    }
+
+    /**
      * Commit a tab to cursor
      */
     protected void commitTab() {

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/CodeEditor.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/CodeEditor.java
@@ -1690,7 +1690,7 @@ public class CodeEditor extends View implements ContentListener, Formatter.Forma
                 // increase the indentation by \t or tabWidthSpaces
                 text.insert(i, endColumn, tabString);
             } else {
-                // line in oddly indented
+                // line is oddly indented
                 // We know that a line can never be oddly indented when it is indented only with tabs
                 // therefore, we insert spaces to align the line
                 text.insert(i, endColumn, StringsKt.repeat(" ", requiredSpaces));
@@ -1737,12 +1737,14 @@ public class CodeEditor extends View implements ContentListener, Formatter.Forma
             if (extraSpaces == 0) {
                 // line is evenly indented
                 // remove tabString.length() characters from the start
-                text.delete(i, 0, i, tabString.length());
+
+                // do not use tabString.length()
+                text.delete(i, endColumn - (tabCount > 0 ? 1 : tabWidth), i, endColumn);
             } else {
-                // line in oddly indented
+                // line is oddly indented
                 // We know that a line can never be oddly indented when it is indented only with tabs
                 // therefore, we delete spaces to align the line
-                text.delete(i, 0, i, extraSpaces);
+                text.delete(i, endColumn - extraSpaces, i, endColumn);
             }
         }
         text.endBatchEdit();

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/CodeEditor.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/CodeEditor.java
@@ -1672,9 +1672,28 @@ public class CodeEditor extends View implements ContentListener, Formatter.Forma
       text.beginBatchEdit();
       for (int i = cursor.getLeftLine(); i <= cursor.getRightLine(); i++) {
           final var line = text.getLineString(i);
-          final var end = Math.min(getTabWidth(), line.length());
-          if (line.substring(0, end).isBlank()) {
+          var end = Math.min(getTabWidth(), line.length());
+          var substring = line.substring(0, end);
+
+          if (substring.isBlank()) {
             text.delete(i, 0, i, end);
+            continue;
+          }
+
+          // check for whitespace from the start instead of end
+          // this is because we are trying to remove indentation from the start
+          // if we check from the end and the the char at end is a whitespace but the char at start
+          // is not, we'll end up deleting unintended character(s)
+          end = 0;
+          while (isWhitespace(substring.charAt(end))) {
+              ++end;
+              if (end >= getTabWidth()) {
+                  break;
+              }
+          }
+
+          if (end != 0) {
+              text.delete(i, 0, i, end);
           }
       }
       text.endBatchEdit();

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/DirectAccessProps.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/DirectAccessProps.java
@@ -371,9 +371,4 @@ public class DirectAccessProps implements Serializable {
      */
     @InvalidateRequired
     public boolean stickyScrollAutoCollapse = true;
-
-    /**
-     * Whether the editor should indent the selected text if `TAB` key is pressed.
-     */
-    public boolean indentSelectionWithTab = true;
 }

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/DirectAccessProps.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/DirectAccessProps.java
@@ -372,4 +372,8 @@ public class DirectAccessProps implements Serializable {
     @InvalidateRequired
     public boolean stickyScrollAutoCollapse = true;
 
+    /**
+     * Whether the editor should indent the selected text if `TAB` key is pressed.
+     */
+    public boolean indentSelectionWithTab = true;
 }

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/EditorKeyEventHandler.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/EditorKeyEventHandler.java
@@ -359,18 +359,11 @@ class EditorKeyEventHandler {
                         } else {
                             editor.getSnippetController().shiftToNextTabStop();
                         }
-                    } if (editor.getProps().indentSelectionWithTab) {
-                        if (isShiftPressed) {
-                            // Shift + TAB -> unindent the [selected] lines
-                            editor.unindentSelection();
-                        } else if (editorCursor.isSelected()) {
-                            // Selection + TAB -> indent the selected lines
-                            editor.indentSelection();
-                        } else {
-                            editor.commitTab();
-                        }
+                    } if (isShiftPressed) {
+                        // Shift + TAB -> unindent the [selected] lines
+                        editor.unindentSelection();
                     } else {
-                        editor.commitTab();
+                        editor.indentOrCommitTab();
                     }
                 }
                 return editorKeyEvent.result(true);

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/EditorKeyEventHandler.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/EditorKeyEventHandler.java
@@ -366,6 +366,8 @@ class EditorKeyEventHandler {
                         } else if (editorCursor.isSelected()) {
                             // Selection + TAB -> indent the selected lines
                             editor.indentSelection();
+                        } else {
+                            editor.commitTab();
                         }
                     } else {
                         editor.commitTab();

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/EditorKeyEventHandler.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/EditorKeyEventHandler.java
@@ -351,7 +351,7 @@ class EditorKeyEventHandler {
                 return editorKeyEvent.result(true);
             case KeyEvent.KEYCODE_TAB:
                 if (editor.isEditable()) {
-                    if (completionWindow.isShowing()) {
+                    if (completionWindow.isShowing() && !isShiftPressed) {
                         completionWindow.select();
                     } else if (editor.getSnippetController().isInSnippet() && !isAltPressed && !isCtrlPressed) {
                         if (isShiftPressed) {
@@ -359,8 +359,14 @@ class EditorKeyEventHandler {
                         } else {
                             editor.getSnippetController().shiftToNextTabStop();
                         }
-                    } if (editor.getProps().indentSelectionWithTab && editorCursor.isSelected()) {
-                        editor.indentSelection();
+                    } if (editor.getProps().indentSelectionWithTab) {
+                        if (isShiftPressed) {
+                            // Shift + TAB -> unindent the [selected] lines
+                            editor.unindentSelection();
+                        } else if (editorCursor.isSelected()) {
+                            // Selection + TAB -> indent the selected lines
+                            editor.indentSelection();
+                        }
                     } else {
                         editor.commitTab();
                     }

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/EditorKeyEventHandler.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/EditorKeyEventHandler.java
@@ -359,6 +359,8 @@ class EditorKeyEventHandler {
                         } else {
                             editor.getSnippetController().shiftToNextTabStop();
                         }
+                    } if (editor.getProps().indentSelectionWithTab && editorCursor.isSelected()) {
+                        editor.indentSelection();
                     } else {
                         editor.commitTab();
                     }

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/SymbolInputView.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/SymbolInputView.java
@@ -121,16 +121,20 @@ public class SymbolInputView extends LinearLayout {
             addView(btn, new LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.MATCH_PARENT));
             int finalI = i;
             btn.setOnClickListener((view) -> {
-                if (editor != null && editor.isEditable()) {
-                    if ("\t".equals(insertText[finalI])) {
-                        if (editor.getSnippetController().isInSnippet()) {
-                            editor.getSnippetController().shiftToNextTabStop();
-                        } else if (editor.getProps().indentSelectionWithTab) {
-                            editor.indentSelection();
-                        }
+                if (editor == null || !editor.isEditable()) {
+                    return;
+                }
+
+                if ("\t".equals(insertText[finalI])) {
+                    if (editor.getSnippetController().isInSnippet()) {
+                        editor.getSnippetController().shiftToNextTabStop();
+                    } else if (editor.getProps().indentSelectionWithTab) {
+                        editor.indentSelection();
                     } else {
                         editor.insertText(insertText[finalI], 1);
                     }
+                } else {
+                    editor.insertText(insertText[finalI], 1);
                 }
             });
         }

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/SymbolInputView.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/SymbolInputView.java
@@ -122,8 +122,12 @@ public class SymbolInputView extends LinearLayout {
             int finalI = i;
             btn.setOnClickListener((view) -> {
                 if (editor != null && editor.isEditable()) {
-                    if ("\t".equals(insertText[finalI]) && editor.getSnippetController().isInSnippet()) {
-                        editor.getSnippetController().shiftToNextTabStop();
+                    if ("\t".equals(insertText[finalI])) {
+                        if (editor.getSnippetController().isInSnippet()) {
+                            editor.getSnippetController().shiftToNextTabStop();
+                        } else if (editor.getProps().indentSelectionWithTab) {
+                            editor.indentSelection();
+                        }
                     } else {
                         editor.insertText(insertText[finalI], 1);
                     }

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/SymbolInputView.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/SymbolInputView.java
@@ -128,7 +128,7 @@ public class SymbolInputView extends LinearLayout {
                 if ("\t".equals(insertText[finalI])) {
                     if (editor.getSnippetController().isInSnippet()) {
                         editor.getSnippetController().shiftToNextTabStop();
-                    } else if (editor.getProps().indentSelectionWithTab) {
+                    } else if (editor.getProps().indentSelectionWithTab && editor.getCursor().isSelected()) {
                         editor.indentSelection();
                     } else {
                         editor.insertText(insertText[finalI], 1);

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/SymbolInputView.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/SymbolInputView.java
@@ -128,10 +128,8 @@ public class SymbolInputView extends LinearLayout {
                 if ("\t".equals(insertText[finalI])) {
                     if (editor.getSnippetController().isInSnippet()) {
                         editor.getSnippetController().shiftToNextTabStop();
-                    } else if (editor.getProps().indentSelectionWithTab && editor.getCursor().isSelected()) {
-                        editor.indentSelection();
                     } else {
-                        editor.insertText(insertText[finalI], 1);
+                        editor.indentOrCommitTab();
                     }
                 } else {
                     editor.insertText(insertText[finalI], 1);

--- a/keybindings.md
+++ b/keybindings.md
@@ -28,3 +28,5 @@ The following key bindings are currently supported by the editor :
 | `Ctrl + Alt + Enter`   | Start a new line before current line.                                                                                                      |
 | `Ctrl + Shift + J`     | Join current line and next line.                                                                                                           |
 | `Shift + Enter`        | Start a new line.                                                                                                                          |
+| `Selection + TAB`      | If the text is selected, pressing the `TAB` key indents all selected lines.                                                                |
+| `Shift + TAB`          | Unindents the current line. If the text is selected, unindents all the selected lines.                                                     |


### PR DESCRIPTION
This adds the ability to indent selected text when the `TAB` key is pressed. The feature can be enabled/disabled using [`DirectAccessProps.indentSelectionWithTab`](https://github.com/itsaky/sora-editor/blob/fe05ee150a7da1bbb62ee341fea2aea0ec7b8a18/editor/src/main/java/io/github/rosemoe/sora/widget/DirectAccessProps.java#L378).

Related issue : AndroidIDEOfficial/AndroidIDE#1229

## Current behavior

https://github.com/Rosemoe/sora-editor/assets/46931079/26974213-e321-4195-88d7-2bb771b19e8d


## New behavior

https://github.com/Rosemoe/sora-editor/assets/46931079/6ab5aa87-5ad1-4dc3-b306-3a115c67559b