### PR TITLE
feat(lang-ts): add API for creating custom Spans in tree sitter languages

### DIFF
--- a/app/src/main/java/io/github/rosemoe/sora/app/MainActivity.kt
+++ b/app/src/main/java/io/github/rosemoe/sora/app/MainActivity.kt
@@ -53,6 +53,8 @@ import io.github.rosemoe.sora.event.PublishSearchResultEvent
 import io.github.rosemoe.sora.event.SelectionChangeEvent
 import io.github.rosemoe.sora.event.SideIconClickEvent
 import io.github.rosemoe.sora.lang.EmptyLanguage
+import io.github.rosemoe.sora.lang.JavaLanguageSpec
+import io.github.rosemoe.sora.lang.TsLanguageJava
 import io.github.rosemoe.sora.lang.diagnostic.DiagnosticRegion
 import io.github.rosemoe.sora.lang.diagnostic.DiagnosticsContainer
 import io.github.rosemoe.sora.lang.styling.TextStyle
@@ -783,42 +785,16 @@ class MainActivity : AppCompatActivity() {
 
                             7 -> loadTMLLauncher.launch("*/*")
                             8 -> {
-                                val lang = TSLanguageJava.newInstance()
-                                editor.setEditorLanguage(TsLanguage(
-                                    TsLanguageSpec(
-                                        TSLanguageJava.newInstance(),
-                                        highlightScmSource = assets.open("tree-sitter-queries/java/highlights.scm").reader().readText(),
-                                        codeBlocksScmSource = assets.open("tree-sitter-queries/java/blocks.scm").reader().readText(),
-                                        bracketsScmSource = assets.open("tree-sitter-queries/java/brackets.scm").reader().readText(),
-                                        localsScmSource = assets.open("tree-sitter-queries/java/locals.scm").reader().readText(),
-                                        localsCaptureSpec = object : LocalsCaptureSpec() {
-
-                                            override fun isScopeCapture(captureName: String): Boolean {
-                                                return captureName == "scope"
-                                            }
-
-                                            override fun isReferenceCapture(captureName: String): Boolean {
-                                                return captureName == "reference"
-                                            }
-
-                                            override fun isDefinitionCapture(captureName: String): Boolean {
-                                                return captureName == "definition.var" || captureName == "definition.field"
-                                            }
-
-                                            override fun isMembersScopeCapture(captureName: String): Boolean {
-                                                return captureName == "scope.members"
-                                            }
-
-                                        }
-                                    )) {
-                                    TextStyle.makeStyle(EditorColorScheme.COMMENT, 0, false, true, false) applyTo "comment"
-                                    TextStyle.makeStyle(EditorColorScheme.KEYWORD, 0, true, false, false) applyTo "keyword"
-                                    TextStyle.makeStyle(EditorColorScheme.LITERAL) applyTo arrayOf("constant.builtin", "string", "number")
-                                    TextStyle.makeStyle(EditorColorScheme.IDENTIFIER_VAR) applyTo arrayOf("variable.builtin", "variable", "constant")
-                                    TextStyle.makeStyle(EditorColorScheme.IDENTIFIER_NAME) applyTo arrayOf("type.builtin", "type", "attribute")
-                                    TextStyle.makeStyle(EditorColorScheme.FUNCTION_NAME) applyTo arrayOf("function.method", "function.builtin", "variable.field")
-                                    TextStyle.makeStyle(EditorColorScheme.OPERATOR) applyTo "operator"
-                                })
+                                editor.setEditorLanguage(
+                                    TsLanguageJava(
+                                        JavaLanguageSpec(
+                                            highlightScmSource = assets.open("tree-sitter-queries/java/highlights.scm").reader().readText(),
+                                            codeBlocksScmSource = assets.open("tree-sitter-queries/java/blocks.scm").reader().readText(),
+                                            bracketsScmSource = assets.open("tree-sitter-queries/java/brackets.scm").reader().readText(),
+                                            localsScmSource = assets.open("tree-sitter-queries/java/locals.scm").reader().readText()
+                                        )
+                                    )
+                                )
                             }
 
                             else -> editor.setEditorLanguage(EmptyLanguage())

--- a/app/src/main/java/io/github/rosemoe/sora/lang/langJava.kt
+++ b/app/src/main/java/io/github/rosemoe/sora/lang/langJava.kt
@@ -69,14 +69,11 @@ class TsJavaAnalyzeManager(
   theme: TsTheme
 ) : TsAnalyzeManager(languageSpec, theme) {
 
-  init {
-    spanFactory = TsJavaSpanFactory(reference, languageSpec.tsQuery, styles)
-  }
-
-  override fun rerun() {
-    super.rerun()
-    spanFactory = TsJavaSpanFactory(reference, languageSpec.tsQuery, styles)
-  }
+  override var styles: Styles = Styles()
+    set(value) {
+      field = value
+      spanFactory = TsJavaSpanFactory(reference, languageSpec.tsQuery, value)
+    }
 }
 
 class TsJavaSpanFactory(

--- a/app/src/main/java/io/github/rosemoe/sora/lang/langJava.kt
+++ b/app/src/main/java/io/github/rosemoe/sora/lang/langJava.kt
@@ -1,0 +1,193 @@
+/*******************************************************************************
+ *    sora-editor - the awesome code editor for Android
+ *    https://github.com/Rosemoe/sora-editor
+ *    Copyright (C) 2020-2023  Rosemoe
+ *
+ *     This library is free software; you can redistribute it and/or
+ *     modify it under the terms of the GNU Lesser General Public
+ *     License as published by the Free Software Foundation; either
+ *     version 2.1 of the License, or (at your option) any later version.
+ *
+ *     This library is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *     Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public
+ *     License along with this library; if not, write to the Free Software
+ *     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *     USA
+ *
+ *     Please contact Rosemoe by email 2073412493@qq.com if you need
+ *     additional information or have any questions
+ ******************************************************************************/
+
+package io.github.rosemoe.sora.lang
+
+import android.graphics.Color
+import com.itsaky.androidide.treesitter.TSQuery
+import com.itsaky.androidide.treesitter.TSQueryCapture
+import com.itsaky.androidide.treesitter.java.TSLanguageJava
+import io.github.rosemoe.sora.editor.ts.LocalsCaptureSpec
+import io.github.rosemoe.sora.editor.ts.TsAnalyzeManager
+import io.github.rosemoe.sora.editor.ts.TsLanguage
+import io.github.rosemoe.sora.editor.ts.TsLanguageSpec
+import io.github.rosemoe.sora.editor.ts.TsTheme
+import io.github.rosemoe.sora.editor.ts.TsThemeBuilder
+import io.github.rosemoe.sora.editor.ts.spans.TsSpanFactory
+import io.github.rosemoe.sora.lang.styling.Span
+import io.github.rosemoe.sora.lang.styling.Styles
+import io.github.rosemoe.sora.lang.styling.TextStyle.makeStyle
+import io.github.rosemoe.sora.lang.styling.line.LineAnchorStyle
+import io.github.rosemoe.sora.lang.styling.line.LineGutterBackground
+import io.github.rosemoe.sora.text.ContentReference
+import io.github.rosemoe.sora.widget.schemes.EditorColorScheme.COMMENT
+import io.github.rosemoe.sora.widget.schemes.EditorColorScheme.FUNCTION_NAME
+import io.github.rosemoe.sora.widget.schemes.EditorColorScheme.IDENTIFIER_NAME
+import io.github.rosemoe.sora.widget.schemes.EditorColorScheme.IDENTIFIER_VAR
+import io.github.rosemoe.sora.widget.schemes.EditorColorScheme.KEYWORD
+import io.github.rosemoe.sora.widget.schemes.EditorColorScheme.LITERAL
+import io.github.rosemoe.sora.widget.schemes.EditorColorScheme.OPERATOR
+
+/**
+ * Tree Sitter language for Java.
+ *
+ * @author Akash Yadav
+ */
+class TsLanguageJava(
+  languageSpec: JavaLanguageSpec,
+  tab: Boolean = false
+) : TsLanguage(languageSpec, tab, { buildTheme() }) {
+
+  override val analyzer: TsAnalyzeManager by lazy {
+    TsJavaAnalyzeManager(languageSpec, tsTheme)
+  }
+}
+
+class TsJavaAnalyzeManager(
+  languageSpec: TsLanguageSpec,
+  theme: TsTheme
+) : TsAnalyzeManager(languageSpec, theme) {
+
+  init {
+    spanFactory = TsJavaSpanFactory(reference, languageSpec.tsQuery, styles)
+  }
+
+  override fun rerun() {
+    super.rerun()
+    spanFactory = TsJavaSpanFactory(reference, languageSpec.tsQuery, styles)
+  }
+}
+
+class TsJavaSpanFactory(
+  private var content : ContentReference?,
+  private var query: TSQuery?,
+  private var styles: Styles?
+) : TsSpanFactory {
+
+  companion object {
+    @JvmStatic
+    private val HEX_REGEX = "#\\b([0-9a-fA-F]{3}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})\\b".toRegex()
+  }
+
+  override fun createSpan(capture: TSQueryCapture, column: Int, spanStyle: Long
+  ): Span {
+    val styles = requireNotNull(styles)
+    val lineAnchorStyle = createColorLineAnchorStyle(capture)
+    if (lineAnchorStyle != null) {
+      styles.addLineStyle(lineAnchorStyle)
+    }
+
+    return Span.obtain(column, spanStyle)
+  }
+
+  private fun createColorLineAnchorStyle(capture: TSQueryCapture) : LineAnchorStyle? {
+    val content = requireNotNull(content?.reference)
+    val query = requireNotNull(query)
+    val styles = requireNotNull(styles)
+
+    val captureName = query.getCaptureNameForId(capture.index)
+    if (captureName != "string") {
+      return null
+    }
+
+    val (start, end) = content.indexer.run {
+      getCharPosition(capture.node.startByte / 2) to getCharPosition(capture.node.endByte / 2)
+    }
+
+    if (start.line != end.line) {
+      styles.eraseLineStyle(start.line, LineGutterBackground::class.java)
+      styles.eraseLineStyle(end.line, LineGutterBackground::class.java)
+      return null
+    }
+
+    val text = content.subContent(start.line, start.column, end.line, end.column)
+    val result = HEX_REGEX.find(text) ?: run {
+      styles.eraseLineStyle(start.line, LineGutterBackground::class.java)
+      styles.eraseLineStyle(end.line, LineGutterBackground::class.java)
+      return null
+    }
+
+    val color = try {
+      Color.parseColor(result.groupValues[0])
+    } catch (err: Exception) {
+      styles.eraseLineStyle(start.line, LineGutterBackground::class.java)
+      styles.eraseLineStyle(end.line, LineGutterBackground::class.java)
+      return null
+    }
+
+    return LineGutterBackground(start.line) { color }
+  }
+
+  override fun close() {
+    content = null
+    query = null
+    styles = null
+  }
+}
+
+fun TsThemeBuilder.buildTheme() {
+  makeStyle(COMMENT, 0, false, true, false) applyTo "comment"
+  makeStyle(KEYWORD, 0, true, false, false) applyTo "keyword"
+  makeStyle(LITERAL) applyTo arrayOf("constant.builtin", "string", "number")
+  makeStyle(IDENTIFIER_VAR) applyTo arrayOf("variable.builtin", "variable",
+    "constant")
+  makeStyle(IDENTIFIER_NAME) applyTo arrayOf("type.builtin", "type",
+    "attribute")
+  makeStyle(FUNCTION_NAME) applyTo arrayOf("function.method",
+    "function.builtin", "variable.field")
+  makeStyle(OPERATOR) applyTo "operator"
+}
+
+class JavaLanguageSpec(
+  highlightScmSource: String,
+  codeBlocksScmSource: String = "",
+  bracketsScmSource: String = "",
+  localsScmSource: String = "",
+) : TsLanguageSpec(
+  TSLanguageJava.getInstance(),
+  highlightScmSource,
+  codeBlocksScmSource,
+  bracketsScmSource,
+  localsScmSource,
+  localsCaptureSpec
+)
+
+private val localsCaptureSpec = object : LocalsCaptureSpec() {
+
+  override fun isScopeCapture(captureName: String): Boolean {
+    return captureName == "scope"
+  }
+
+  override fun isReferenceCapture(captureName: String): Boolean {
+    return captureName == "reference"
+  }
+
+  override fun isDefinitionCapture(captureName: String): Boolean {
+    return captureName == "definition.var" || captureName == "definition.field"
+  }
+
+  override fun isMembersScopeCapture(captureName: String): Boolean {
+    return captureName == "scope.members"
+  }
+}

--- a/editor/src/main/java/io/github/rosemoe/sora/lang/styling/color/ResolvableColor.kt
+++ b/editor/src/main/java/io/github/rosemoe/sora/lang/styling/color/ResolvableColor.kt
@@ -30,7 +30,7 @@ import io.github.rosemoe.sora.widget.CodeEditor
  *
  * @author Rosemoe
  */
-interface ResolvableColor {
+fun interface ResolvableColor {
     /**
      * Resolve this color
      * @return Color int

--- a/language-treesitter/src/main/java/io/github/rosemoe/sora/editor/ts/TsAnalyzeManager.kt
+++ b/language-treesitter/src/main/java/io/github/rosemoe/sora/editor/ts/TsAnalyzeManager.kt
@@ -35,6 +35,7 @@ import com.itsaky.androidide.treesitter.string.UTF16String
 import com.itsaky.androidide.treesitter.string.UTF16StringFactory
 import io.github.rosemoe.sora.data.ObjectAllocator
 import io.github.rosemoe.sora.editor.ts.spans.DefaultSpanFactory
+import io.github.rosemoe.sora.editor.ts.spans.TsSpanFactory
 import io.github.rosemoe.sora.lang.analysis.AnalyzeManager
 import io.github.rosemoe.sora.lang.analysis.StyleReceiver
 import io.github.rosemoe.sora.lang.styling.CodeBlock
@@ -51,7 +52,7 @@ open class TsAnalyzeManager(val languageSpec: TsLanguageSpec, var theme: TsTheme
     var extraArguments: Bundle? = null
     var thread: TsLooperThread? = null
     var styles = Styles()
-    var spanFactory = DefaultSpanFactory()
+    var spanFactory : TsSpanFactory = DefaultSpanFactory()
 
     fun updateTheme(theme: TsTheme) {
         this.theme = theme
@@ -160,6 +161,7 @@ open class TsAnalyzeManager(val languageSpec: TsLanguageSpec, var theme: TsTheme
             }
         }
         (styles.spans as LineSpansGenerator?)?.tree?.close()
+        spanFactory.close()
     }
 
     companion object {

--- a/language-treesitter/src/main/java/io/github/rosemoe/sora/editor/ts/TsAnalyzeManager.kt
+++ b/language-treesitter/src/main/java/io/github/rosemoe/sora/editor/ts/TsAnalyzeManager.kt
@@ -34,13 +34,13 @@ import com.itsaky.androidide.treesitter.TSTree
 import com.itsaky.androidide.treesitter.string.UTF16String
 import com.itsaky.androidide.treesitter.string.UTF16StringFactory
 import io.github.rosemoe.sora.data.ObjectAllocator
+import io.github.rosemoe.sora.editor.ts.spans.DefaultSpanFactory
 import io.github.rosemoe.sora.lang.analysis.AnalyzeManager
 import io.github.rosemoe.sora.lang.analysis.StyleReceiver
 import io.github.rosemoe.sora.lang.styling.CodeBlock
 import io.github.rosemoe.sora.lang.styling.Styles
 import io.github.rosemoe.sora.text.CharPosition
 import io.github.rosemoe.sora.text.ContentReference
-import java.util.Collections
 import java.util.concurrent.LinkedBlockingQueue
 
 open class TsAnalyzeManager(val languageSpec: TsLanguageSpec, var theme: TsTheme) :
@@ -51,6 +51,7 @@ open class TsAnalyzeManager(val languageSpec: TsLanguageSpec, var theme: TsTheme
     var extraArguments: Bundle? = null
     var thread: TsLooperThread? = null
     var styles = Styles()
+    var spanFactory = DefaultSpanFactory()
 
     fun updateTheme(theme: TsTheme) {
         this.theme = theme
@@ -208,7 +209,8 @@ open class TsAnalyzeManager(val languageSpec: TsLanguageSpec, var theme: TsTheme
                     reference!!.reference,
                     theme,
                     languageSpec,
-                    scopedVariables
+                    scopedVariables,
+                    spanFactory
                 )
                 val oldBlocks = styles.blocks
                 updateCodeBlocks()

--- a/language-treesitter/src/main/java/io/github/rosemoe/sora/editor/ts/TsAnalyzeManager.kt
+++ b/language-treesitter/src/main/java/io/github/rosemoe/sora/editor/ts/TsAnalyzeManager.kt
@@ -51,8 +51,9 @@ open class TsAnalyzeManager(val languageSpec: TsLanguageSpec, var theme: TsTheme
     var reference: ContentReference? = null
     var extraArguments: Bundle? = null
     var thread: TsLooperThread? = null
-    var styles = Styles()
     var spanFactory : TsSpanFactory = DefaultSpanFactory()
+
+    open var styles = Styles()
 
     fun updateTheme(theme: TsTheme) {
         this.theme = theme

--- a/language-treesitter/src/main/java/io/github/rosemoe/sora/editor/ts/TsLanguage.kt
+++ b/language-treesitter/src/main/java/io/github/rosemoe/sora/editor/ts/TsLanguage.kt
@@ -58,7 +58,7 @@ open class TsLanguage(
         }
     }
 
-    private var tsTheme = TsThemeBuilder(languageSpec.tsQuery).apply { themeDescription() }.theme
+    protected var tsTheme = TsThemeBuilder(languageSpec.tsQuery).apply { themeDescription() }.theme
 
     open val analyzer by lazy {
         TsAnalyzeManager(languageSpec, tsTheme)

--- a/language-treesitter/src/main/java/io/github/rosemoe/sora/editor/ts/spans/DefaultSpanFactory.kt
+++ b/language-treesitter/src/main/java/io/github/rosemoe/sora/editor/ts/spans/DefaultSpanFactory.kt
@@ -37,4 +37,7 @@ open class DefaultSpanFactory : TsSpanFactory {
   override fun createSpan(capture: TSQueryCapture, column: Int, spanStyle: Long) : Span {
     return Span.obtain(column, spanStyle)
   }
+
+  override fun close() {
+  }
 }

--- a/language-treesitter/src/main/java/io/github/rosemoe/sora/editor/ts/spans/DefaultSpanFactory.kt
+++ b/language-treesitter/src/main/java/io/github/rosemoe/sora/editor/ts/spans/DefaultSpanFactory.kt
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ *    sora-editor - the awesome code editor for Android
+ *    https://github.com/Rosemoe/sora-editor
+ *    Copyright (C) 2020-2023  Rosemoe
+ *
+ *     This library is free software; you can redistribute it and/or
+ *     modify it under the terms of the GNU Lesser General Public
+ *     License as published by the Free Software Foundation; either
+ *     version 2.1 of the License, or (at your option) any later version.
+ *
+ *     This library is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *     Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public
+ *     License along with this library; if not, write to the Free Software
+ *     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *     USA
+ *
+ *     Please contact Rosemoe by email 2073412493@qq.com if you need
+ *     additional information or have any questions
+ ******************************************************************************/
+
+package io.github.rosemoe.sora.editor.ts.spans
+
+import com.itsaky.androidide.treesitter.TSQueryCapture
+import io.github.rosemoe.sora.lang.styling.Span
+
+/**
+ * Default implementation of the [TsSpanFactory].
+ *
+ * @author Akash Yadav
+ */
+open class DefaultSpanFactory : TsSpanFactory {
+
+  override fun createSpan(capture: TSQueryCapture, column: Int, spanStyle: Long) : Span {
+    return Span.obtain(column, spanStyle)
+  }
+}

--- a/language-treesitter/src/main/java/io/github/rosemoe/sora/editor/ts/spans/TsSpanFactory.kt
+++ b/language-treesitter/src/main/java/io/github/rosemoe/sora/editor/ts/spans/TsSpanFactory.kt
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ *    sora-editor - the awesome code editor for Android
+ *    https://github.com/Rosemoe/sora-editor
+ *    Copyright (C) 2020-2023  Rosemoe
+ *
+ *     This library is free software; you can redistribute it and/or
+ *     modify it under the terms of the GNU Lesser General Public
+ *     License as published by the Free Software Foundation; either
+ *     version 2.1 of the License, or (at your option) any later version.
+ *
+ *     This library is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *     Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public
+ *     License along with this library; if not, write to the Free Software
+ *     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *     USA
+ *
+ *     Please contact Rosemoe by email 2073412493@qq.com if you need
+ *     additional information or have any questions
+ ******************************************************************************/
+
+package io.github.rosemoe.sora.editor.ts.spans
+
+import com.itsaky.androidide.treesitter.TSQueryCapture
+import io.github.rosemoe.sora.lang.styling.Span
+
+/**
+ * Factory for creating spans for the tree sitter analyze manager.
+ *
+ * @author Akash Yadav
+ */
+interface TsSpanFactory {
+
+  /**
+   * Creates the spans using the provided data.
+   *
+   * @param capture The query capture. More information about the node can be found using the [TSQueryCapture.node] object.
+   * @param column The column that should be used to create the span.
+   * @param spanStyle The style for the span.
+   * @return The [Span] object.
+   */
+  fun createSpan(capture: TSQueryCapture, column: Int, spanStyle: Long): Span
+}

--- a/language-treesitter/src/main/java/io/github/rosemoe/sora/editor/ts/spans/TsSpanFactory.kt
+++ b/language-treesitter/src/main/java/io/github/rosemoe/sora/editor/ts/spans/TsSpanFactory.kt
@@ -32,7 +32,7 @@ import io.github.rosemoe.sora.lang.styling.Span
  *
  * @author Akash Yadav
  */
-interface TsSpanFactory {
+interface TsSpanFactory : AutoCloseable {
 
   /**
    * Creates the spans using the provided data.


### PR DESCRIPTION
This PR adds a new API that allows `TsAnalyzeManager` implementations to create custom `Span`s and styles for the captures.

## API

`TsAnalyzeManager` implementations can provide a `TsSpanFactory` instance which is used to create the spans (and styles for the capture). The span factory is provided with the `TSQueryCapture` object representing the query capture along with the column index and styles for the `Span`.

The default implementation of the factory (`DefaultTsSpanFactory`) simply creates the spans using `Span.obtain`.

## Example

As an example, the tree-sitter based Java language in the sample application uses a custom span factory to add a `LineGutterBackground` anchor style to lines which contain a HEX color string.

<img src="https://github.com/Rosemoe/sora-editor/assets/46931079/574895f2-8f8d-4e36-ae55-e05920277a9a" width="350" />

