### PR TITLE
feat(editor): add support for static span colors

### DIFF
--- a/app/src/main/assets/samples/sample.txt
+++ b/app/src/main/assets/samples/sample.txt
@@ -28,6 +28,14 @@ package io.github.rosemoe.sora.util;
  */
 public class Numbers {
 
+    final static String RED = "#f44336";
+
+    final static String BLUE = "#2196f3";
+
+    final static String GREEN = "#4caf50";
+
+    final static String SOME_COLOR = "#abcdef";
+
     final static char [] DigitTens = {
             '0', '0', '0', '0', '0', '0', '0', '0', '0', '0',
             '1', '1', '1', '1', '1', '1', '1', '1', '1', '1',

--- a/editor/src/main/java/io/github/rosemoe/sora/lang/styling/Span.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/lang/styling/Span.java
@@ -24,12 +24,8 @@
 package io.github.rosemoe.sora.lang.styling;
 
 import androidx.annotation.NonNull;
-
-import java.util.Collection;
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.BlockingQueue;
-
 import io.github.rosemoe.sora.widget.schemes.EditorColorScheme;
+import java.util.Collection;
 
 /**
  * The span model
@@ -38,7 +34,7 @@ import io.github.rosemoe.sora.widget.schemes.EditorColorScheme;
  */
 public class Span {
 
-    private static final BlockingQueue<Span> cacheQueue = new ArrayBlockingQueue<>(8192 * 2);
+    private static final SpanPool<Span> spanPool = new SpanPool<>(Span::new);
 
     public int column;
     /**
@@ -67,14 +63,7 @@ public class Span {
      * The result object will be initialized with the given arguments.
      */
     public static Span obtain(int column, long style) {
-        Span span = cacheQueue.poll();
-        if (span == null) {
-            return new Span(column, style);
-        } else {
-            span.column = column;
-            span.style = style;
-            return span;
-        }
+        return spanPool.obtain(column, style);
     }
 
     /**
@@ -133,7 +122,7 @@ public class Span {
     public boolean recycle() {
         column = underlineColor = 0;
         style = 0;
-        return cacheQueue.offer(this);
+        return spanPool.offer(this);
     }
 
     public int getForegroundColorId() {

--- a/editor/src/main/java/io/github/rosemoe/sora/lang/styling/SpanPool.kt
+++ b/editor/src/main/java/io/github/rosemoe/sora/lang/styling/SpanPool.kt
@@ -1,0 +1,91 @@
+/*******************************************************************************
+ *    sora-editor - the awesome code editor for Android
+ *    https://github.com/Rosemoe/sora-editor
+ *    Copyright (C) 2020-2023  Rosemoe
+ *
+ *     This library is free software; you can redistribute it and/or
+ *     modify it under the terms of the GNU Lesser General Public
+ *     License as published by the Free Software Foundation; either
+ *     version 2.1 of the License, or (at your option) any later version.
+ *
+ *     This library is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *     Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public
+ *     License along with this library; if not, write to the Free Software
+ *     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *     USA
+ *
+ *     Please contact Rosemoe by email 2073412493@qq.com if you need
+ *     additional information or have any questions
+ ******************************************************************************/
+
+package io.github.rosemoe.sora.lang.styling
+
+import java.util.concurrent.ArrayBlockingQueue
+
+/**
+ * A pool of [Span] objects. Subclasses of [Span]s can use this pool to recycle
+ * and reuse [Span] objects of a specific type.
+ *
+ * **Note**: Instances of this class should be stored in static variables.
+ *
+ * @param capacity The capacity of the pool.
+ * @property factory A factory method to create new instances of [SpanT].
+ * @author Akash Yadav
+ */
+open class SpanPool<SpanT : Span> @JvmOverloads constructor(
+  capacity: Int = DEFAULT_CAPACITY,
+  private val factory: (column: Int, style: Long) -> SpanT
+) {
+
+  private val cacheQueue = ArrayBlockingQueue<SpanT>(capacity)
+
+  companion object {
+
+    /**
+     * Small capacity (8192 objects). This should be used for spans that will not
+     * be used too frequently (for example, [StaticColorSpan]).
+     */
+    const val CAPACITY_SMALL = 8192
+
+    /**
+     * Small capacity ([CAPACITY_SMALL] * 2 objects). This should be used for spans
+     * that will be used frequently (for example, [Span]).
+     */
+    const val CAPACITY_LARGE = CAPACITY_SMALL * 2
+
+    /**
+     * The default pool capacity. Same as [CAPACITY_LARGE].
+     */
+    const val DEFAULT_CAPACITY = CAPACITY_LARGE
+  }
+
+  /**
+   * Return the given span to the pool. This method should not be called directly.
+   * Instead, call [Span.recycle] and it should automatically return itself to the
+   * pool.
+   *
+   * @param span The [SpanT] to recycle.
+   * @return Wheter the span was recycled successfully.
+   */
+  open fun offer(span: SpanT): Boolean {
+    return cacheQueue.offer(span)
+  }
+
+  /**
+   * Returns a recycled span or creates a new one if the pool is empty.
+   *
+   * @param column The new column index for the span.
+   * @param style The new style for the span.
+   * @return The recycled [SpanT], or a new instance of [SpanT] if the pool is empty.
+   */
+  open fun obtain(column: Int, style: Long): SpanT {
+    return cacheQueue.poll()?.also {
+      it.column = column
+      it.style = style
+    } ?: factory(column, style)
+  }
+}

--- a/editor/src/main/java/io/github/rosemoe/sora/lang/styling/StaticColorSpan.kt
+++ b/editor/src/main/java/io/github/rosemoe/sora/lang/styling/StaticColorSpan.kt
@@ -39,18 +39,79 @@ import io.github.rosemoe.sora.widget.schemes.EditorColorScheme
  * @property foregroundColor The foreground color integer for the span.
  * @author Akash Yadav
  */
-class StaticColorSpan(val backgroundColor: Int,
-                      val foregroundColor: Int,
-                      column: Int,
-                      style: Long
+class StaticColorSpan private constructor(var backgroundColor: Int,
+                                          var foregroundColor: Int, column: Int,
+                                          style: Long
 ) : Span(column, style) {
 
+  constructor(column: Int, style: Long) : this(0, 0, column, style)
+
   init {
-    require(backgroundColorId == EditorColorScheme.STATIC_SPAN_BACKGROUND) {
-      "Background color id for ${javaClass.simpleName} must be EditorColorScheme.STATIC_SPAN_BACKGROUND"
+    validateColorIds()
+  }
+
+  companion object {
+
+    private val spanPool = SpanPool(SpanPool.CAPACITY_SMALL, ::StaticColorSpan)
+
+    @JvmStatic
+    fun obtain(backgroundColor: Int, foregroundColor: Int, column: Int,
+               style: Long
+    ): StaticColorSpan {
+      return spanPool.obtain(column, style).also {
+        it.backgroundColor = backgroundColor
+        it.foregroundColor = foregroundColor
+        it.validateColorIds()
+      }
     }
-    require(foregroundColorId == EditorColorScheme.STATIC_SPAN_FOREGROUND) {
-      "Foreground color id for ${javaClass.simpleName} must be EditorColorScheme.STATIC_SPAN_FOREGROUND"
+
+    @JvmStatic
+    private fun StaticColorSpan.validateColorIds() {
+      require(
+        backgroundColorId == EditorColorScheme.STATIC_SPAN_BACKGROUND || backgroundColorId == 0) {
+        "Background color id for ${javaClass.simpleName} must be EditorColorScheme.STATIC_SPAN_BACKGROUND or 0"
+      }
+      require(
+        foregroundColorId == EditorColorScheme.STATIC_SPAN_FOREGROUND || foregroundColorId == 0) {
+        "Foreground color id for ${javaClass.simpleName} must be EditorColorScheme.STATIC_SPAN_FOREGROUND or 0"
+      }
     }
+  }
+
+  override fun recycle(): Boolean {
+    this.backgroundColor = 0
+    this.foregroundColor = 0
+    this.column = 0
+    this.underlineColor = 0
+    this.style = 0
+    return spanPool.offer(this)
+  }
+
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other !is StaticColorSpan) return false
+    if (!super.equals(other)) return false
+
+    if (backgroundColor != other.backgroundColor) return false
+    if (foregroundColor != other.foregroundColor) return false
+
+    return true
+  }
+
+  override fun hashCode(): Int {
+    var result = super.hashCode()
+    result = 31 * result + backgroundColor
+    result = 31 * result + foregroundColor
+    return result
+  }
+
+  override fun toString(): String {
+    return "StaticColorSpan{" +
+      "column=" + column +
+      ", style=" + style +
+      ", underlineColor=" + underlineColor +
+      ", bgColor=" + backgroundColor +
+      ", fgColor=" + foregroundColor +
+      "}";
   }
 }

--- a/editor/src/main/java/io/github/rosemoe/sora/lang/styling/StaticColorSpan.kt
+++ b/editor/src/main/java/io/github/rosemoe/sora/lang/styling/StaticColorSpan.kt
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ *    sora-editor - the awesome code editor for Android
+ *    https://github.com/Rosemoe/sora-editor
+ *    Copyright (C) 2020-2023  Rosemoe
+ *
+ *     This library is free software; you can redistribute it and/or
+ *     modify it under the terms of the GNU Lesser General Public
+ *     License as published by the Free Software Foundation; either
+ *     version 2.1 of the License, or (at your option) any later version.
+ *
+ *     This library is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *     Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public
+ *     License along with this library; if not, write to the Free Software
+ *     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *     USA
+ *
+ *     Please contact Rosemoe by email 2073412493@qq.com if you need
+ *     additional information or have any questions
+ ******************************************************************************/
+
+package io.github.rosemoe.sora.lang.styling
+
+import io.github.rosemoe.sora.widget.schemes.EditorColorScheme
+
+/**
+ * A static color span.
+ *
+ * The span has pre-defined colors for background and foreground (i.e. the colors
+ * are not resolved from the color scheme, but are specified directly in the span).
+ * The [span style][AdvancedSpan.style] for this type of span must specify
+ * [EditorColorScheme.STATIC_SPAN_BACKGROUND] as its background color id and
+ * [EditorColorScheme.STATIC_SPAN_FOREGROUND] as its foreground color id.
+ *
+ * @property backgroundColor The background color integer for the span.
+ * @property foregroundColor The foreground color integer for the span.
+ * @author Akash Yadav
+ */
+class StaticColorSpan(val backgroundColor: Int,
+                      val foregroundColor: Int,
+                      column: Int,
+                      style: Long
+) : Span(column, style) {
+
+  init {
+    require(backgroundColorId == EditorColorScheme.STATIC_SPAN_BACKGROUND) {
+      "Background color id for ${javaClass.simpleName} must be EditorColorScheme.STATIC_SPAN_BACKGROUND"
+    }
+    require(foregroundColorId == EditorColorScheme.STATIC_SPAN_FOREGROUND) {
+      "Foreground color id for ${javaClass.simpleName} must be EditorColorScheme.STATIC_SPAN_FOREGROUND"
+    }
+  }
+}

--- a/editor/src/main/java/io/github/rosemoe/sora/util/RendererUtils.kt
+++ b/editor/src/main/java/io/github/rosemoe/sora/util/RendererUtils.kt
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ *    sora-editor - the awesome code editor for Android
+ *    https://github.com/Rosemoe/sora-editor
+ *    Copyright (C) 2020-2023  Rosemoe
+ *
+ *     This library is free software; you can redistribute it and/or
+ *     modify it under the terms of the GNU Lesser General Public
+ *     License as published by the Free Software Foundation; either
+ *     version 2.1 of the License, or (at your option) any later version.
+ *
+ *     This library is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *     Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public
+ *     License along with this library; if not, write to the Free Software
+ *     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *     USA
+ *
+ *     Please contact Rosemoe by email 2073412493@qq.com if you need
+ *     additional information or have any questions
+ ******************************************************************************/
+
+package io.github.rosemoe.sora.util
+
+import io.github.rosemoe.sora.lang.styling.Span
+import io.github.rosemoe.sora.lang.styling.StaticColorSpan
+import io.github.rosemoe.sora.widget.schemes.EditorColorScheme
+
+/**
+ * Utility methods for use in editor renderer.
+ *
+ * @author Akash Yadav
+ */
+object RendererUtils {
+
+  /**
+   * Get the background color for the given span.
+   */
+  @JvmStatic
+  fun getBackgroundColor(span: Span, colorScheme: EditorColorScheme): Int? {
+    val colorId = span.backgroundColorId
+
+    if (span is StaticColorSpan && colorId == EditorColorScheme.STATIC_SPAN_BACKGROUND) {
+      return span.backgroundColor
+    }
+
+    if (colorId == 0) {
+      return null
+    }
+
+    return colorScheme.getColor(colorId)
+  }
+
+  /**
+   * Get the foreground color for the given span.
+   */
+  @JvmStatic
+  fun getForegroundColor(span: Span, colorScheme: EditorColorScheme): Int {
+    val colorId = span.foregroundColorId
+
+    if (span is StaticColorSpan && colorId == EditorColorScheme.STATIC_SPAN_FOREGROUND) {
+      return span.foregroundColor
+    }
+
+    return colorScheme.getColor(colorId)
+  }
+}

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/EditorRenderer.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/EditorRenderer.java
@@ -45,6 +45,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
 
+import io.github.rosemoe.sora.util.RendererUtils;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -453,7 +454,8 @@ public class EditorRenderer {
 
             if (offsetX + width > 0 || !visibleOnly) {
 
-                ExternalRenderer renderer = span instanceof AdvancedSpan ? ((AdvancedSpan) span).renderer : null;
+                AdvancedSpan advancedSpan = span instanceof AdvancedSpan ? (AdvancedSpan) span : null;
+                ExternalRenderer renderer = advancedSpan != null ? advancedSpan.renderer: null;
 
                 // Invoke external renderer preDraw
                 if (renderer != null && renderer.requirePreDraw()) {
@@ -480,21 +482,21 @@ public class EditorRenderer {
                     lastStyle = styleBits;
                 }
 
-                int backgroundColorId = span.getBackgroundColorId();
-                if (backgroundColorId != 0) {
-                    if (paintStart != paintEnd) {
-                        tmpRect.top = editor.getRowTop(row);
-                        tmpRect.bottom = editor.getRowBottom(row);
-                        tmpRect.left = offsetX;
-                        tmpRect.right = tmpRect.left + width;
-                        paintGeneral.setColor(editor.getColorScheme().getColor(backgroundColorId));
-                        canvas.drawRoundRect(tmpRect, editor.getRowHeight() * editor.getProps().roundTextBackgroundFactor, editor.getRowHeight() * editor.getProps().roundTextBackgroundFactor, paintGeneral);
-                    }
+                // unboxing may result in NPE!
+                Integer backgroundColor = RendererUtils.getBackgroundColor(span, editor.getColorScheme());
+                if (backgroundColor != null && paintStart != paintEnd) {
+                    tmpRect.top = editor.getRowTop(row);
+                    tmpRect.bottom = editor.getRowBottom(row);
+                    tmpRect.left = offsetX;
+                    tmpRect.right = tmpRect.left + width;
+                    paintGeneral.setColor(backgroundColor);
+                    canvas.drawRoundRect(tmpRect, editor.getRowHeight() * editor.getProps().roundTextBackgroundFactor, editor.getRowHeight() * editor.getProps().roundTextBackgroundFactor, paintGeneral);
                 }
 
 
                 // Draw text
-                drawRegionTextDirectional(canvas, offsetX, editor.getRowBaseline(row), line, paintStart, paintEnd, span.column, spanEnd, columnCount, editor.getColorScheme().getColor(span.getForegroundColorId()));
+                int foregroundColor = RendererUtils.getForegroundColor(span, editor.getColorScheme());
+                drawRegionTextDirectional(canvas, offsetX, editor.getRowBaseline(row), line, paintStart, paintEnd, span.column, spanEnd, columnCount, foregroundColor);
 
                 // Draw strikethrough
                 if (TextStyle.isStrikeThrough(span.style)) {
@@ -1383,20 +1385,20 @@ public class EditorRenderer {
                         lastStyle = styleBits;
                     }
 
-                    int backgroundColorId = span.getBackgroundColorId();
-                    if (backgroundColorId != 0) {
-                        if (paintStart != paintEnd) {
-                            tmpRect.top = editor.getRowTop(row) - editor.getOffsetY();
-                            tmpRect.bottom = editor.getRowBottom(row) - editor.getOffsetY();
-                            tmpRect.left = paintingOffset;
-                            tmpRect.right = tmpRect.left + width;
-                            paintGeneral.setColor(editor.getColorScheme().getColor(backgroundColorId));
-                            canvas.drawRoundRect(tmpRect, editor.getRowHeight() * editor.getProps().roundTextBackgroundFactor, editor.getRowHeight() * editor.getProps().roundTextBackgroundFactor, paintGeneral);
-                        }
+                    // unboxing may result in NPE!
+                    Integer backgroundColor = RendererUtils.getBackgroundColor(span, editor.getColorScheme());
+                    if (backgroundColor != null && paintStart != paintEnd) {
+                        tmpRect.top = editor.getRowTop(row) - editor.getOffsetY();
+                        tmpRect.bottom = editor.getRowBottom(row) - editor.getOffsetY();
+                        tmpRect.left = paintingOffset;
+                        tmpRect.right = tmpRect.left + width;
+                        paintGeneral.setColor(backgroundColor);
+                        canvas.drawRoundRect(tmpRect, editor.getRowHeight() * editor.getProps().roundTextBackgroundFactor, editor.getRowHeight() * editor.getProps().roundTextBackgroundFactor, paintGeneral);
                     }
 
                     // Draw text
-                    drawRegionTextDirectional(canvas, paintingOffset, editor.getRowBaseline(row) - editor.getOffsetY(), line, paintStart, paintEnd, span.column, spanEnd, columnCount, editor.getColorScheme().getColor(span.getForegroundColorId()));
+                    int foregroundColor = RendererUtils.getForegroundColor(span, editor.getColorScheme());
+                    drawRegionTextDirectional(canvas, paintingOffset, editor.getRowBaseline(row) - editor.getOffsetY(), line, paintStart, paintEnd, span.column, spanEnd, columnCount, foregroundColor);
 
                     // Draw strikethrough
                     if (TextStyle.isStrikeThrough(styleBits)) {

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/schemes/EditorColorScheme.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/schemes/EditorColorScheme.java
@@ -151,12 +151,15 @@ public class EditorColorScheme {
     public static final int SIGNATURE_TEXT_NORMAL = 58;
     public static final int SIGNATURE_TEXT_HIGHLIGHTED_PARAMETER = 59;
 
+    public static final int STATIC_SPAN_BACKGROUND = 63;
+    public static final int STATIC_SPAN_FOREGROUND = 64;
+
     public static final int SIGNATURE_BACKGROUND = 60;
 
     /**
      * Max pre-defined color id
      */
-    protected static final int END_COLOR_ID = 62;
+    protected static final int END_COLOR_ID = 64;
 
 
     /**
@@ -262,6 +265,7 @@ public class EditorColorScheme {
             case LINE_DIVIDER:
                 color = 0xeeeeeeee;
                 break;
+            case STATIC_SPAN_BACKGROUND:
             case WHOLE_BACKGROUND:
             case LINE_NUMBER_PANEL_TEXT:
             case COMPLETION_WND_BACKGROUND:
@@ -271,6 +275,7 @@ public class EditorColorScheme {
             case OPERATOR:
                 color = 0xFF0066D6;
                 break;
+            case STATIC_SPAN_FOREGROUND:
             case TEXT_NORMAL:
                 color = 0xFF333333;
                 break;

--- a/language-java/src/main/java/io/github/rosemoe/sora/langs/java/JavaIncrementalAnalyzeManager.java
+++ b/language-java/src/main/java/io/github/rosemoe/sora/langs/java/JavaIncrementalAnalyzeManager.java
@@ -24,23 +24,21 @@
 package io.github.rosemoe.sora.langs.java;
 
 import android.os.Bundle;
-
 import androidx.annotation.NonNull;
-
-import java.util.List;
-import java.util.Stack;
-
 import io.github.rosemoe.sora.lang.analysis.AsyncIncrementalAnalyzeManager;
 import io.github.rosemoe.sora.lang.brackets.SimpleBracketsCollector;
 import io.github.rosemoe.sora.lang.completion.IdentifierAutoComplete;
 import io.github.rosemoe.sora.lang.styling.CodeBlock;
 import io.github.rosemoe.sora.lang.styling.Span;
+import io.github.rosemoe.sora.lang.styling.StaticColorSpan;
 import io.github.rosemoe.sora.lang.styling.TextStyle;
 import io.github.rosemoe.sora.text.Content;
 import io.github.rosemoe.sora.text.ContentReference;
 import io.github.rosemoe.sora.util.ArrayList;
 import io.github.rosemoe.sora.util.IntPair;
 import io.github.rosemoe.sora.widget.schemes.EditorColorScheme;
+import java.util.List;
+import java.util.Stack;
 
 public class JavaIncrementalAnalyzeManager extends AsyncIncrementalAnalyzeManager<State, Long> {
 
@@ -269,9 +267,25 @@ public class JavaIncrementalAnalyzeManager extends AsyncIncrementalAnalyzeManage
                 case CHARACTER_LITERAL:
                 case FLOATING_POINT_LITERAL:
                 case INTEGER_LITERAL:
-                case STRING:
                     classNamePrevious = false;
                     spans.add(Span.obtain(offset, TextStyle.makeStyle(EditorColorScheme.LITERAL, true)));
+                    break;
+                case STRING:
+                    classNamePrevious = false;
+                    final var span = new StaticColorSpan(
+                      0xff4caf50,
+                      0xffffffff,
+                      offset,
+                      TextStyle.makeStyle(
+                        EditorColorScheme.STATIC_SPAN_FOREGROUND,
+                        EditorColorScheme.STATIC_SPAN_BACKGROUND,
+                        true,
+                        false,
+                        false,
+                        true
+                      )
+                    );
+                    spans.add(span);
                     break;
                 case INT:
                 case LONG:

--- a/language-java/src/main/java/io/github/rosemoe/sora/langs/java/JavaIncrementalAnalyzeManager.java
+++ b/language-java/src/main/java/io/github/rosemoe/sora/langs/java/JavaIncrementalAnalyzeManager.java
@@ -267,25 +267,9 @@ public class JavaIncrementalAnalyzeManager extends AsyncIncrementalAnalyzeManage
                 case CHARACTER_LITERAL:
                 case FLOATING_POINT_LITERAL:
                 case INTEGER_LITERAL:
-                    classNamePrevious = false;
-                    spans.add(Span.obtain(offset, TextStyle.makeStyle(EditorColorScheme.LITERAL, true)));
-                    break;
                 case STRING:
                     classNamePrevious = false;
-                    final var span = StaticColorSpan.obtain(
-                      0xff4caf50,
-                      0xffffffff,
-                      offset,
-                      TextStyle.makeStyle(
-                        EditorColorScheme.STATIC_SPAN_FOREGROUND,
-                        EditorColorScheme.STATIC_SPAN_BACKGROUND,
-                        true,
-                        false,
-                        false,
-                        true
-                      )
-                    );
-                    spans.add(span);
+                    spans.add(Span.obtain(offset, TextStyle.makeStyle(EditorColorScheme.LITERAL, true)));
                     break;
                 case INT:
                 case LONG:

--- a/language-java/src/main/java/io/github/rosemoe/sora/langs/java/JavaIncrementalAnalyzeManager.java
+++ b/language-java/src/main/java/io/github/rosemoe/sora/langs/java/JavaIncrementalAnalyzeManager.java
@@ -272,7 +272,7 @@ public class JavaIncrementalAnalyzeManager extends AsyncIncrementalAnalyzeManage
                     break;
                 case STRING:
                     classNamePrevious = false;
-                    final var span = new StaticColorSpan(
+                    final var span = StaticColorSpan.obtain(
                       0xff4caf50,
                       0xffffffff,
                       offset,


### PR DESCRIPTION
This PR adds support for static color spans in the editor.

## Static color spans

Static color spans are spans whose background and foreground colors are pre-defined during the source code analysis. Two new color IDs have been added to `EditorColorScheme` :

- `STATIC_SPAN_BACKGROUND` -> for the background
- `STATIC_SPAN_FOREGROUND` -> for the foreground

Here is a demo implementation of the feature (the color is same for all string tokens) :
<img src="https://github.com/Rosemoe/sora-editor/assets/46931079/d254b8e2-434b-407f-84b8-36c3860c24e8" width="350" />

## Known issues

There is only one issue that I have noticed and it is not specifically related to this feature addition :

If a span has a custom background color and if that span is in the selection region, the span background color hides the selected text background color. This happens because the selection is drawn before the span (i.e. the span color overlaps the selection color).

This can be resolved by either :
- Draw the selection region after the span background is drawn.
- Skip drawing the span background if it is in the selection region.
- Invert the span background color by if it is in the selection region.

The last two approaches should also handle the case where the span is partially in the selection region. These two approaches should be preferred in my opinion.

## Additional changes

A new class (`SpanPool`) has been added to recycle and reuse the `Span` objects (and its subclasses by creating multiple pools). The implementation of the pool is same as what was being used earlier for caching. However, multiple pools can now be created with different capacities.