### PR TITLE
fix: replace 'showState' in EditorPopupWindow with 'PopupWindow.isShowing()'

### DIFF
--- a/editor/src/main/java/io/github/rosemoe/sora/widget/base/EditorPopupWindow.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/base/EditorPopupWindow.java
@@ -63,7 +63,6 @@ public class EditorPopupWindow {
     private final int features;
     private final int[] locationBuffer = new int[2];
     private final EventReceiver<ScrollEvent> scrollListener;
-    private boolean showState;
     private boolean registerFlag;
     private boolean registered;
     private View parentView;
@@ -154,7 +153,7 @@ public class EditorPopupWindow {
     }
 
     public boolean isShowing() {
-        return showState;
+        return getPopup().isShowing();
     }
 
     /**
@@ -269,19 +268,17 @@ public class EditorPopupWindow {
      * Show the window if appropriate
      */
     public void show() {
-        if (showState) {
+        if (isShowing()) {
             return;
         }
         applyWindowAttributes(true);
-        showState = true;
     }
 
     /**
      * Dismiss the window
      */
     public void dismiss() {
-        if (showState) {
-            showState = false;
+        if (isShowing()) {
             window.dismiss();
         }
     }


### PR DESCRIPTION
If the `PopupWindow` is dismissed by the system, the `EditorPopupWindow.dismiss()` will not be called and hence the `showState` in `EditorPopupWindow` and the actual show state of the popup window will differ.

This PR fixes the above issue by removing usage of `showState` in `EditorPopupWindow` and replacing it with `PopupWindow.isShowing()` call.