### PR TITLE
Add support for adding multiple spans for single capture in TsSpanFactory

### DIFF
--- a/app/src/main/java/io/github/rosemoe/sora/lang/langJava.kt
+++ b/app/src/main/java/io/github/rosemoe/sora/lang/langJava.kt
@@ -186,7 +186,7 @@ class TsJavaSpanFactory(
             spans.add(Span.obtain(column + e + 1, spanStyle))
         }
 
-        return spans.toList()
+        return spans
     }
 
     override fun close() {

--- a/app/src/main/java/io/github/rosemoe/sora/lang/langJava.kt
+++ b/app/src/main/java/io/github/rosemoe/sora/lang/langJava.kt
@@ -25,6 +25,8 @@
 package io.github.rosemoe.sora.lang
 
 import android.graphics.Color
+import android.util.Log
+import androidx.core.graphics.ColorUtils
 import com.itsaky.androidide.treesitter.TSQuery
 import com.itsaky.androidide.treesitter.TSQueryCapture
 import com.itsaky.androidide.treesitter.java.TSLanguageJava
@@ -34,13 +36,13 @@ import io.github.rosemoe.sora.editor.ts.TsLanguage
 import io.github.rosemoe.sora.editor.ts.TsLanguageSpec
 import io.github.rosemoe.sora.editor.ts.TsTheme
 import io.github.rosemoe.sora.editor.ts.TsThemeBuilder
-import io.github.rosemoe.sora.editor.ts.spans.TsSpanFactory
+import io.github.rosemoe.sora.editor.ts.spans.DefaultSpanFactory
 import io.github.rosemoe.sora.lang.styling.Span
+import io.github.rosemoe.sora.lang.styling.StaticColorSpan
 import io.github.rosemoe.sora.lang.styling.Styles
 import io.github.rosemoe.sora.lang.styling.TextStyle.makeStyle
-import io.github.rosemoe.sora.lang.styling.line.LineAnchorStyle
-import io.github.rosemoe.sora.lang.styling.line.LineGutterBackground
 import io.github.rosemoe.sora.text.ContentReference
+import io.github.rosemoe.sora.widget.schemes.EditorColorScheme
 import io.github.rosemoe.sora.widget.schemes.EditorColorScheme.COMMENT
 import io.github.rosemoe.sora.widget.schemes.EditorColorScheme.FUNCTION_NAME
 import io.github.rosemoe.sora.widget.schemes.EditorColorScheme.IDENTIFIER_NAME
@@ -80,111 +82,168 @@ class TsJavaSpanFactory(
   private var content : ContentReference?,
   private var query: TSQuery?,
   private var styles: Styles?
-) : TsSpanFactory {
+) : DefaultSpanFactory() {
 
   companion object {
     @JvmStatic
     private val HEX_REGEX = "#\\b([0-9a-fA-F]{3}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})\\b".toRegex()
   }
 
-  override fun createSpan(capture: TSQueryCapture, column: Int, spanStyle: Long
-  ): Span {
-    val styles = requireNotNull(styles)
-    val lineAnchorStyle = createColorLineAnchorStyle(capture)
-    if (lineAnchorStyle != null) {
-      styles.addLineStyle(lineAnchorStyle)
+    override fun createSpans(
+        capture: TSQueryCapture, column: Int, spanStyle: Long
+    ): List<Span> {
+        val content = requireNotNull(content?.reference)
+        val query = requireNotNull(query)
+
+        val captureName = query.getCaptureNameForId(capture.index)
+        if (captureName != "string") {
+            return super.createSpans(capture, column, spanStyle)
+        }
+
+        val (start, end) = content.indexer.run {
+            getCharPosition(capture.node.startByte / 2) to getCharPosition(capture.node.endByte / 2)
+        }
+
+        if (start.line != end.line || start.column != column) {
+            return super.createSpans(capture, column, spanStyle)
+        }
+
+        val text = content.subContent(start.line, start.column, end.line, end.column)
+        val results = HEX_REGEX.findAll(text)
+
+        val spans = mutableListOf<Span>()
+        var s = -1
+        var e = -1
+        results.forEach { result ->
+            if (e != -1 && e < result.range.first) {
+                // there is some interval between previous color span
+                // and this color span
+                // fill the gap
+                spans.add(Span.obtain(column + e + 1, spanStyle))
+            }
+
+            if (s == -1) {
+                s = result.range.first
+            }
+            e = result.range.last
+
+            val color = try {
+                var str = result.groupValues[1]
+                if (str.length == 3) {
+                    // HEX color is in the form of #FFF
+                    // convert it to #FFFFFF format (6 character long)
+                    val r = str[0]
+                    val g = str[1]
+                    val b = str[2]
+                    str = "$r$r$g$g$b$b"
+                }
+
+                if (str.length == 6) {
+                    // Prepend alpha value
+                    str = "FF${str}"
+                }
+
+                java.lang.Long.parseLong(str, 16)
+            } catch (e: Exception) {
+                Log.e("JavaSpanFactory", "Failed to parse hex color. color=$text", e)
+                return@forEach
+            }.toInt()
+
+            val textColor = if (ColorUtils.calculateLuminance(color) > 0.5f) {
+                Color.BLACK
+            } else {
+                Color.WHITE
+            }
+
+            val col = column + result.range.first
+            val span = StaticColorSpan.obtain(
+                color,
+                textColor,
+                col,
+                makeStyle(
+                    EditorColorScheme.STATIC_SPAN_FOREGROUND,
+                    EditorColorScheme.STATIC_SPAN_BACKGROUND,
+                    false,
+                    false,
+                    false,
+                    true
+                )
+            )
+
+            spans.add(span)
+        }
+
+        if (spans.isEmpty()) {
+            return super.createSpans(capture, column, spanStyle)
+        }
+
+        // make sure that the default style is used for unmatched regions
+        if (s != 0) {
+            spans.add(0, Span.obtain(column, spanStyle))
+        }
+
+        if (e != text.lastIndex) {
+            spans.add(Span.obtain(column + e + 1, spanStyle))
+        }
+
+        return spans.toList()
     }
 
-    return Span.obtain(column, spanStyle)
-  }
-
-  private fun createColorLineAnchorStyle(capture: TSQueryCapture) : LineAnchorStyle? {
-    val content = requireNotNull(content?.reference)
-    val query = requireNotNull(query)
-    val styles = requireNotNull(styles)
-
-    val captureName = query.getCaptureNameForId(capture.index)
-    if (captureName != "string") {
-      return null
+    override fun close() {
+        content = null
+        query = null
+        styles = null
     }
-
-    val (start, end) = content.indexer.run {
-      getCharPosition(capture.node.startByte / 2) to getCharPosition(capture.node.endByte / 2)
-    }
-
-    if (start.line != end.line) {
-      styles.eraseLineStyle(start.line, LineGutterBackground::class.java)
-      styles.eraseLineStyle(end.line, LineGutterBackground::class.java)
-      return null
-    }
-
-    val text = content.subContent(start.line, start.column, end.line, end.column)
-    val result = HEX_REGEX.find(text) ?: run {
-      styles.eraseLineStyle(start.line, LineGutterBackground::class.java)
-      styles.eraseLineStyle(end.line, LineGutterBackground::class.java)
-      return null
-    }
-
-    val color = try {
-      Color.parseColor(result.groupValues[0])
-    } catch (err: Exception) {
-      styles.eraseLineStyle(start.line, LineGutterBackground::class.java)
-      styles.eraseLineStyle(end.line, LineGutterBackground::class.java)
-      return null
-    }
-
-    return LineGutterBackground(start.line) { color }
-  }
-
-  override fun close() {
-    content = null
-    query = null
-    styles = null
-  }
 }
 
 fun TsThemeBuilder.buildTheme() {
-  makeStyle(COMMENT, 0, false, true, false) applyTo "comment"
-  makeStyle(KEYWORD, 0, true, false, false) applyTo "keyword"
-  makeStyle(LITERAL) applyTo arrayOf("constant.builtin", "string", "number")
-  makeStyle(IDENTIFIER_VAR) applyTo arrayOf("variable.builtin", "variable",
-    "constant")
-  makeStyle(IDENTIFIER_NAME) applyTo arrayOf("type.builtin", "type",
-    "attribute")
-  makeStyle(FUNCTION_NAME) applyTo arrayOf("function.method",
-    "function.builtin", "variable.field")
-  makeStyle(OPERATOR) applyTo "operator"
+    makeStyle(COMMENT, 0, false, true, false) applyTo "comment"
+    makeStyle(KEYWORD, 0, true, false, false) applyTo "keyword"
+    makeStyle(LITERAL) applyTo arrayOf("constant.builtin", "string", "number")
+    makeStyle(IDENTIFIER_VAR) applyTo arrayOf(
+        "variable.builtin", "variable",
+        "constant"
+    )
+    makeStyle(IDENTIFIER_NAME) applyTo arrayOf(
+        "type.builtin", "type",
+        "attribute"
+    )
+    makeStyle(FUNCTION_NAME) applyTo arrayOf(
+        "function.method",
+        "function.builtin", "variable.field"
+    )
+    makeStyle(OPERATOR) applyTo "operator"
 }
 
 class JavaLanguageSpec(
-  highlightScmSource: String,
-  codeBlocksScmSource: String = "",
-  bracketsScmSource: String = "",
-  localsScmSource: String = "",
+    highlightScmSource: String,
+    codeBlocksScmSource: String = "",
+    bracketsScmSource: String = "",
+    localsScmSource: String = "",
 ) : TsLanguageSpec(
-  TSLanguageJava.getInstance(),
-  highlightScmSource,
-  codeBlocksScmSource,
-  bracketsScmSource,
-  localsScmSource,
-  localsCaptureSpec
+    TSLanguageJava.getInstance(),
+    highlightScmSource,
+    codeBlocksScmSource,
+    bracketsScmSource,
+    localsScmSource,
+    localsCaptureSpec
 )
 
 private val localsCaptureSpec = object : LocalsCaptureSpec() {
 
-  override fun isScopeCapture(captureName: String): Boolean {
-    return captureName == "scope"
-  }
+    override fun isScopeCapture(captureName: String): Boolean {
+        return captureName == "scope"
+    }
 
-  override fun isReferenceCapture(captureName: String): Boolean {
-    return captureName == "reference"
-  }
+    override fun isReferenceCapture(captureName: String): Boolean {
+        return captureName == "reference"
+    }
 
-  override fun isDefinitionCapture(captureName: String): Boolean {
-    return captureName == "definition.var" || captureName == "definition.field"
-  }
+    override fun isDefinitionCapture(captureName: String): Boolean {
+        return captureName == "definition.var" || captureName == "definition.field"
+    }
 
-  override fun isMembersScopeCapture(captureName: String): Boolean {
-    return captureName == "scope.members"
-  }
+    override fun isMembersScopeCapture(captureName: String): Boolean {
+        return captureName == "scope.members"
+    }
 }

--- a/language-treesitter/src/main/java/io/github/rosemoe/sora/editor/ts/spans/DefaultSpanFactory.kt
+++ b/language-treesitter/src/main/java/io/github/rosemoe/sora/editor/ts/spans/DefaultSpanFactory.kt
@@ -34,8 +34,8 @@ import io.github.rosemoe.sora.lang.styling.Span
  */
 open class DefaultSpanFactory : TsSpanFactory {
 
-  override fun createSpan(capture: TSQueryCapture, column: Int, spanStyle: Long) : Span {
-    return Span.obtain(column, spanStyle)
+  override fun createSpans(capture: TSQueryCapture, column: Int, spanStyle: Long): List<Span> {
+    return listOf(Span.obtain(column, spanStyle))
   }
 
   override fun close() {

--- a/language-treesitter/src/main/java/io/github/rosemoe/sora/editor/ts/spans/TsSpanFactory.kt
+++ b/language-treesitter/src/main/java/io/github/rosemoe/sora/editor/ts/spans/TsSpanFactory.kt
@@ -42,5 +42,5 @@ interface TsSpanFactory : AutoCloseable {
    * @param spanStyle The style for the span.
    * @return The [Span] object.
    */
-  fun createSpan(capture: TSQueryCapture, column: Int, spanStyle: Long): Span
+  fun createSpans(capture: TSQueryCapture, column: Int, spanStyle: Long): List<Span>
 }

--- a/language-treesitter/src/main/java/io/github/rosemoe/sora/editor/ts/spans/TsSpanFactory.kt
+++ b/language-treesitter/src/main/java/io/github/rosemoe/sora/editor/ts/spans/TsSpanFactory.kt
@@ -38,9 +38,9 @@ interface TsSpanFactory : AutoCloseable {
    * Creates the spans using the provided data.
    *
    * @param capture The query capture. More information about the node can be found using the [TSQueryCapture.node] object.
-   * @param column The column that should be used to create the span.
-   * @param spanStyle The style for the span.
-   * @return The [Span] object.
+   * @param column The start column index for the span.
+   * @param spanStyle The style for the spans.
+   * @return The [Span] objects.
    */
   fun createSpans(capture: TSQueryCapture, column: Int, spanStyle: Long): List<Span>
 }


### PR DESCRIPTION
This PR updates the `TsSpanFactory` API so that multiple (not-overlapping) spans can be created for a single capture. This feature is useful for cases where a capture's node(s) may need to be represented with different spans.

An example implementation for this (with static color spans) has been added to the Tree Sitter Java language in the sample application. Here is a screenshot :

<img src="https://github.com/Rosemoe/sora-editor/assets/46931079/540463d7-6c72-4641-8948-e5345402933e" width="300" />
