### PR TITLE
fix: add null checks for CodeBlocks

### DIFF
--- a/editor/src/main/java/io/github/rosemoe/sora/lang/styling/Styles.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/lang/styling/Styles.java
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
 import io.github.rosemoe.sora.data.ObjectAllocator;
@@ -107,6 +108,7 @@ public class Styles {
      * @param block Info of code block
      */
     public void addCodeBlock(@NonNull CodeBlock block) {
+        Objects.requireNonNull(block, "CodeBlock must not be null");
         blocks.add(block);
     }
 

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/CodeEditor.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/CodeEditor.java
@@ -1526,6 +1526,9 @@ public class CodeEditor extends View implements ContentListener, Formatter.Forma
         }
         for (int i = min; i <= max; i++) {
             CodeBlock block = blocks.get(i);
+            if (block == null) {
+                continue;
+            }
             if (block.endLine >= line && block.startLine <= line) {
                 int dis = block.endLine - block.startLine;
                 if (dis < minDis) {

--- a/language-treesitter/src/main/java/io/github/rosemoe/sora/editor/ts/TsAnalyzeManager.kt
+++ b/language-treesitter/src/main/java/io/github/rosemoe/sora/editor/ts/TsAnalyzeManager.kt
@@ -273,7 +273,8 @@ open class TsAnalyzeManager(val languageSpec: TsLanguageSpec, var theme: TsTheme
                     match = it.nextMatch()
                 }
             }
-            val distinct = blocks.distinct().toMutableList()
+            // sequence should be preferred here in order to avoid allocating multiple lists and sets
+            val distinct = blocks.asSequence().distinct().toMutableList()
             styles.blocks = distinct
             styles.finishBuilding()
         }


### PR DESCRIPTION
This PR adds null checks in `CodeEditor.findCursorBlock()` and `Styles.addCodeBlock` to avoid runtime exception when querying the blocks. An issue related to this was reported in AndroidIDEOfficial/AndroidIDE#1388.