### PR TITLE
Add method to clear GrammarRegistry and leave TextMateSymbolPairMatch Enabled by default 

### DIFF
--- a/language-textmate/src/main/java/io/github/rosemoe/sora/langs/textmate/TextMateSymbolPairMatch.java
+++ b/language-textmate/src/main/java/io/github/rosemoe/sora/langs/textmate/TextMateSymbolPairMatch.java
@@ -54,7 +54,7 @@ public class TextMateSymbolPairMatch extends SymbolPairMatch {
         super(new SymbolPairMatch.DefaultSymbolPairs());
         this.language = language;
 
-        updatePair();
+        setEnabled(true);
     }
 
     public void setEnabled(boolean enabled) {

--- a/language-textmate/src/main/java/io/github/rosemoe/sora/langs/textmate/registry/GrammarRegistry.java
+++ b/language-textmate/src/main/java/io/github/rosemoe/sora/langs/textmate/registry/GrammarRegistry.java
@@ -291,11 +291,15 @@ public class GrammarRegistry {
         return grammarName == null ? name : grammarName;
     }
 
-    public synchronized void clear(boolean clearParent) {
+    public synchronized void clear(boolean clearParent, boolean clearRegistry) {
         grammarFileName2ScopeName.clear();
         languageConfigurationMap.clear();
         scopeName2GrammarId.clear();
         scopeName2GrammarDefinition.clear();
+
+        if (clearRegistry) {
+            registry = new Registry();
+        }
 
         if (parent != null && clearParent) {
             parent.clear(true);
@@ -303,7 +307,7 @@ public class GrammarRegistry {
     }
 
     public void clear() {
-        clear(false);
+        clear(true, true);
     }
 
     public synchronized void dispose(boolean closeParent) {
@@ -315,7 +319,7 @@ public class GrammarRegistry {
         registry = null;
 
         // False value because dispose will clean the parent if "closeParent" is true 
-        clear(false);
+        clear(false, false);
 
         // if (parent == null) {
         // ? need?

--- a/language-textmate/src/main/java/io/github/rosemoe/sora/langs/textmate/registry/GrammarRegistry.java
+++ b/language-textmate/src/main/java/io/github/rosemoe/sora/langs/textmate/registry/GrammarRegistry.java
@@ -291,6 +291,21 @@ public class GrammarRegistry {
         return grammarName == null ? name : grammarName;
     }
 
+    public synchronized void clear(boolean clearParent) {
+        grammarFileName2ScopeName.clear();
+        languageConfigurationMap.clear();
+        scopeName2GrammarId.clear();
+        scopeName2GrammarDefinition.clear();
+
+        if (parent != null && clearParent) {
+            parent.clear(true);
+        }
+    }
+
+    public void clear() {
+        clear(false);
+    }
+
     public synchronized void dispose(boolean closeParent) {
 
         if (registry == null) {
@@ -298,10 +313,9 @@ public class GrammarRegistry {
         }
 
         registry = null;
-        grammarFileName2ScopeName.clear();
-        languageConfigurationMap.clear();
-        scopeName2GrammarId.clear();
-        scopeName2GrammarDefinition.clear();
+
+        // False value because dispose will clean the parent if "closeParent" is true 
+        clear(false);
 
         // if (parent == null) {
         // ? need?
@@ -311,7 +325,6 @@ public class GrammarRegistry {
         if (parent != null && closeParent) {
             parent.dispose(true);
         }
-
 
     }
 


### PR DESCRIPTION
I'm making an improvement to my application, a grammar is only registered when the user opens a file, if the grammar of the open file is not registered it will register it as soon as the user opens the file, and the clear method will help when the editor activity is destroyed, clearing all grammars 