### PR TITLE
feat: add feature switches to enable/disable soft keyboard

### DIFF
--- a/app/src/main/java/io/github/rosemoe/sora/app/MainActivity.kt
+++ b/app/src/main/java/io/github/rosemoe/sora/app/MainActivity.kt
@@ -41,11 +41,7 @@ import android.widget.PopupMenu
 import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts.GetContent
 import androidx.appcompat.app.AppCompatActivity
-import com.itsaky.androidide.treesitter.java.TSLanguageJava
 import io.github.rosemoe.sora.app.databinding.ActivityMainBinding
-import io.github.rosemoe.sora.editor.ts.LocalsCaptureSpec
-import io.github.rosemoe.sora.editor.ts.TsLanguage
-import io.github.rosemoe.sora.editor.ts.TsLanguageSpec
 import io.github.rosemoe.sora.event.ContentChangeEvent
 import io.github.rosemoe.sora.event.EditorKeyEvent
 import io.github.rosemoe.sora.event.KeyBindingEvent
@@ -57,7 +53,6 @@ import io.github.rosemoe.sora.lang.JavaLanguageSpec
 import io.github.rosemoe.sora.lang.TsLanguageJava
 import io.github.rosemoe.sora.lang.diagnostic.DiagnosticRegion
 import io.github.rosemoe.sora.lang.diagnostic.DiagnosticsContainer
-import io.github.rosemoe.sora.lang.styling.TextStyle
 import io.github.rosemoe.sora.langs.java.JavaLanguage
 import io.github.rosemoe.sora.langs.textmate.TextMateColorScheme
 import io.github.rosemoe.sora.langs.textmate.TextMateLanguage
@@ -962,6 +957,16 @@ class MainActivity : AppCompatActivity() {
 
             R.id.load_test_file -> {
                 openAssetsFile("samples/big_sample.txt")
+            }
+
+            R.id.softKbdEnabled -> {
+                editor.isSoftKeyboardEnabled = !editor.isSoftKeyboardEnabled
+                item.isChecked = editor.isSoftKeyboardEnabled
+            }
+
+            R.id.disableSoftKbdOnHardKbd -> {
+                editor.isDisableSoftKbdIfHardKbdAvailable = !editor.isDisableSoftKbdIfHardKbdAvailable
+                item.isChecked = editor.isDisableSoftKbdIfHardKbdAvailable
             }
         }
         return super.onOptionsItemSelected(item)

--- a/app/src/main/res/menu/menu_main.xml
+++ b/app/src/main/res/menu/menu_main.xml
@@ -90,6 +90,16 @@
                 android:checkable="true"
                 android:checked="true"
                 android:title="@string/open_completion_window_animation" />
+            <item
+                android:id="@+id/softKbdEnabled"
+                android:checkable="true"
+                android:checked="true"
+                android:title="@string/enable_soft_keyboard" />
+            <item
+                android:id="@+id/disableSoftKbdOnHardKbd"
+                android:checkable="true"
+                android:checked="true"
+                android:title="@string/hide_soft_kbd_if_hard_kbd_available" />
         </menu>
     </item>
     <item android:title="@string/line_info_panel_position">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -84,4 +84,6 @@
     <string name="search_option_regex">Regex</string>
     <string name="search_option_whole_word">Whole Word</string>
     <string name="search_option_match_case">Match Case</string>
+    <string name="enable_soft_keyboard">Enable soft keyboard</string>
+    <string name="hide_soft_kbd_if_hard_kbd_available">Hide soft kbd if hard kbd available</string>
 </resources>

--- a/editor/src/main/java/io/github/rosemoe/sora/util/KeyboardUtils.kt
+++ b/editor/src/main/java/io/github/rosemoe/sora/util/KeyboardUtils.kt
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ *    sora-editor - the awesome code editor for Android
+ *    https://github.com/Rosemoe/sora-editor
+ *    Copyright (C) 2020-2023  Rosemoe
+ *
+ *     This library is free software; you can redistribute it and/or
+ *     modify it under the terms of the GNU Lesser General Public
+ *     License as published by the Free Software Foundation; either
+ *     version 2.1 of the License, or (at your option) any later version.
+ *
+ *     This library is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *     Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public
+ *     License along with this library; if not, write to the Free Software
+ *     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *     USA
+ *
+ *     Please contact Rosemoe by email 2073412493@qq.com if you need
+ *     additional information or have any questions
+ ******************************************************************************/
+
+package io.github.rosemoe.sora.util
+
+import android.content.Context
+import android.content.res.Configuration
+
+import android.inputmethodservice.InputMethodService
+
+/**
+ * Utility functions for keyboard.
+ *
+ * @author Akash Yadav
+ */
+object KeyboardUtils {
+
+    /**
+     * Check if hardware keyboard is connected.
+     * Based on default implementation of [InputMethodService.onEvaluateInputViewShown].
+     *
+     * https://developer.android.com/guide/topics/resources/providing-resources#ImeQualifier
+     *
+     * @param context The Context for operations.
+     * @return Returns `true` if device has hardware keys for text input or an external hardware
+     * keyboard is connected, otherwise `false`.
+     */
+    fun isHardKeyboardConnected(context: Context?): Boolean {
+        if (context == null) return false
+        val config = context.resources.configuration
+        return (config.keyboard != Configuration.KEYBOARD_NOKEYS
+                || config.hardKeyboardHidden == Configuration.HARDKEYBOARDHIDDEN_NO)
+    }
+}


### PR DESCRIPTION
This feature add support for the following feature switches :

- To enable or disable the soft keyboard.
- To disable the soft keyboard if a hardware keyboard is available (either built-in or external).