### PR TITLE
feat(editor): add old cursor position for selection change event

### DIFF
--- a/editor/src/main/java/io/github/rosemoe/sora/event/SelectionChangeEvent.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/event/SelectionChangeEvent.java
@@ -24,6 +24,7 @@
 package io.github.rosemoe.sora.event;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import io.github.rosemoe.sora.text.CharPosition;
 import io.github.rosemoe.sora.widget.CodeEditor;
@@ -74,12 +75,18 @@ public class SelectionChangeEvent extends Event {
      * From mouse
      */
     public final static int CAUSE_MOUSE_INPUT = 8;
+    @Nullable
+    private final CharPosition oldLeft;
+    @Nullable
+    private final CharPosition oldRight;
     private final CharPosition left;
     private final CharPosition right;
     private final int cause;
 
-    public SelectionChangeEvent(@NonNull CodeEditor editor, int cause) {
+    public SelectionChangeEvent(@NonNull CodeEditor editor, @Nullable CharPosition oldLeft, @Nullable CharPosition oldRight, int cause) {
         super(editor);
+        this.oldLeft = oldLeft;
+        this.oldRight = oldRight;
         var cursor = editor.getText().getCursor();
         left = cursor.left();
         right = cursor.right();
@@ -99,6 +106,22 @@ public class SelectionChangeEvent extends Event {
      */
     public int getCause() {
         return cause;
+    }
+
+    /**
+     * Get the last left selection before changed
+     */
+    @Nullable
+    public CharPosition getOldLeft() {
+        return oldLeft;
+    }
+
+    /**
+     * Get the last right selection's position before changed
+     */
+    @Nullable
+    public CharPosition getOldRight() {
+        return oldRight;
     }
 
     /**

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/CodeEditor.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/CodeEditor.java
@@ -314,6 +314,7 @@ public class CodeEditor extends View implements ContentListener, Formatter.Forma
     private ClipboardManager clipboardManager;
     private InputMethodManager inputMethodManager;
     private Cursor cursor;
+    private Cursor lastCursor;
     private Content text;
     private Matrix matrix;
     private EditorColorScheme colorScheme;
@@ -4376,7 +4377,15 @@ public class CodeEditor extends View implements ContentListener, Formatter.Forma
      * Called when the text is edited or {@link CodeEditor#setSelection} is called
      */
     protected void onSelectionChanged(int cause) {
-        dispatchEvent(new SelectionChangeEvent(this, cause));
+        CharPosition oldLeft = null;
+        CharPosition oldRight = null;
+        final Cursor lastCursor =  this.lastCursor;
+        if (lastCursor != null) {
+            oldLeft = lastCursor.left();
+            oldRight = lastCursor.right();
+        }
+        dispatchEvent(new SelectionChangeEvent(this, oldLeft, oldRight, cause));
+        this.lastCursor = cursor;
     }
 
     protected void releaseEdgeEffects() {


### PR DESCRIPTION
feat(editor): add old cursor position before changed for selection change event