### PR TITLE
fix: provide space and tab count to Language.getIndentAdvance()

### DIFF
--- a/editor/src/main/java/io/github/rosemoe/sora/lang/Language.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/lang/Language.java
@@ -24,12 +24,10 @@
 package io.github.rosemoe.sora.lang;
 
 import android.os.Bundle;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.UiThread;
 import androidx.annotation.WorkerThread;
-
 import io.github.rosemoe.sora.lang.analysis.AnalyzeManager;
 import io.github.rosemoe.sora.lang.completion.CompletionCancelledException;
 import io.github.rosemoe.sora.lang.completion.CompletionHelper;
@@ -121,15 +119,36 @@ public interface Language {
                              @NonNull Bundle extraArguments) throws CompletionCancelledException;
 
     /**
-     * Get delta indent spaces count
+     * Get delta indent spaces count.
      *
-     * @param content Content of given line
-     * @param line    0-indexed line number
-     * @param column  Column on the given line, where a line separator is inserted
+     * @param content Content of given line.
+     * @param line    0-indexed line number. The indentation is applied on line index: {@code line + 1}.
+     * @param column  Column on the given line, where a line separator is inserted.
      * @return Delta count of indent spaces. It can be a negative/positive number or zero.
      */
     @UiThread
     int getIndentAdvance(@NonNull ContentReference content, int line, int column);
+
+    /**
+     * Get delta indent spaces count.
+     *
+     * @param content          Content of given line.
+     * @param line             0-indexed line number. The indentation is applied on line index: {@code line + 1}.
+     * @param column           Column on the given line, where a line separator is inserted.
+     * @param spaceCountOnLine The number of spaces on {@code line}.
+     * @param tabCountOnLine   The number of tabs on {@code line}.
+     * @return Delta count of indent spaces. It can be a negative/positive number or zero.
+     */
+    @UiThread
+    default int getIndentAdvance(
+      @NonNull ContentReference content,
+      int line,
+      int column,
+      int spaceCountOnLine,
+      int tabCountOnLine
+    ) {
+        return getIndentAdvance(content, line, column);
+    }
 
     /**
      * Use tab to format

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/CodeEditor.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/CodeEditor.java
@@ -1961,21 +1961,28 @@ public class CodeEditor extends View implements ContentListener, Formatter.Forma
                 char first = text.charAt(0);
                 if (first == '\n' || first == '\r') {
                     String line = this.text.getLineString(cur.getLeftLine());
-                    int p = 0, count = 0;
+                    int p = 0, spaceCount = 0, tabCount = 0;
                     while (p < cur.getLeftColumn()) {
                         if (isWhitespace(line.charAt(p))) {
                             if (line.charAt(p) == '\t') {
-                                count += tabWidth;
+                                ++tabCount;
                             } else {
-                                count++;
+                                ++spaceCount;
                             }
                             p++;
                         } else {
                             break;
                         }
                     }
+                    int count = spaceCount + (tabCount * tabWidth);
                     try {
-                        count += editorLanguage.getIndentAdvance(new ContentReference(this.text), cur.getLeftLine(), cur.getLeftColumn());
+                        count += editorLanguage.getIndentAdvance(
+                          new ContentReference(this.text),
+                          cur.getLeftLine(),
+                          cur.getLeftColumn(),
+                          spaceCount,
+                          tabCount
+                        );
                     } catch (Exception e) {
                         Log.w(LOG_TAG, "Language object error", e);
                     }


### PR DESCRIPTION
Currently, the `getIndentAdvance` method in `Language` interface expects the implementations to return the number of spaces to increase or decrease relative to the current line's indentation (`newLineIndent = currLineIndent + getIndentAdvance(...)`). However, the method does not provide the indentation count on the current line, which might be problematic in some cases (for example, if the implementation computes the overall indentation, not the delta). This PR adds a new overload for `getIndentAdvance` which provides the number of spaces and tabs on the current line.