### PR TITLE
fix crash on textmate on lower APIs

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -56,9 +56,6 @@ android {
             proguardFiles("proguard-rules.pro")
         }
     }
-    compileOptions {
-        isCoreLibraryDesugaringEnabled = true
-    }
     androidResources {
         additionalParameters.add("--warn-manifest-validation")
     }
@@ -82,9 +79,6 @@ android {
 dependencies {
     implementation(libs.androidx.constraintlayout)
     implementation(libs.gms.instantapps)
-
-    // Desugar
-    coreLibraryDesugaring(libs.desugar)
 
     // androidx & material
     implementation(libs.material)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
-agp = "8.3.0"
+agp = "8.3.1"
 kotlin = "1.9.22"
-tsBinding = "4.1.0"
+tsBinding = "4.3.1"
 lsp4j = "0.22.0"
 androidxAnnotation = "1.7.1"
 
@@ -13,7 +13,6 @@ androidx-core-ktx = { module = "androidx.core:core-ktx", version = "1.12.0" }
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version = "1.6.1" }
 androidx-test-junit = { module = "androidx.test.ext:junit", version = "1.1.5" }
 androidx-test-espresso = { module = "androidx.test.espresso:espresso-core", version = "3.5.1" }
-desugar = { module = "com.android.tools:desugar_jdk_libs", version = "2.0.4" }
 kotlinx-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version = "1.8.0" }
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
 lifecycle-runtime = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version = "2.7.0"}

--- a/language-textmate/build.gradle.kts
+++ b/language-textmate/build.gradle.kts
@@ -49,15 +49,9 @@ android {
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
         }
     }
-    compileOptions {
-        // Flag to enable support for the new language APIs
-        isCoreLibraryDesugaringEnabled = true
-    }
 }
 
 dependencies {
-    coreLibraryDesugaring(libs.desugar)
-
     compileOnly(projects.editor)
     implementation(libs.gson)
     implementation(libs.jcodings)

--- a/language-textmate/src/main/java/org/eclipse/tm4e/core/internal/rule/RuleFactory.java
+++ b/language-textmate/src/main/java/org/eclipse/tm4e/core/internal/rule/RuleFactory.java
@@ -247,7 +247,15 @@ public final class RuleFactory {
             }
         }
 
-        return new CompilePatternsResult(r.toArray(RuleId[]::new), patterns.size() != r.size());
+        RuleId[] ruleIds = new RuleId[r.size()];
+
+        int i = 0;
+        for (final RuleId ruleId : r) {
+            ruleIds[i] = ruleId;
+            i++;
+        }
+
+        return new CompilePatternsResult(ruleIds, patterns.size() != r.size());
     }
 
     private RuleFactory() {


### PR DESCRIPTION
Bumps `AGP` and `tree-sitter` version and fixes crash on lower APIs using textmate. I ran a build without desugaring and all features appear to work as expected, so I've disabled desugaring. Although #551 would be a great idea, that'd require some time, so I've made these changes to accomodate snapshot builds for now.