### PR TITLE
--bugfix=TextMateSymbolPairMatch.SymbolPairEx.shouldReplace

### DIFF
--- a/language-textmate/src/main/java/io/github/rosemoe/sora/langs/textmate/TextMateSymbolPairMatch.java
+++ b/language-textmate/src/main/java/io/github/rosemoe/sora/langs/textmate/TextMateSymbolPairMatch.java
@@ -172,6 +172,10 @@ public class TextMateSymbolPairMatch extends SymbolPairMatch {
             if (editor.getCursor().isSelected()) {
                 return isSurroundingPair;
             }
+            // No text was selected，so should not complete surrounding pair
+            if (isSurroundingPair) {
+                return false;
+            }
 
             if (notInTokenTypeArray == null) {
                 return true;


### PR DESCRIPTION
--bugfix=TextMateSymbolPairMatch.SymbolPairEx.shouldReplace add isSurroundingPair judgement when no text was selected.