### PR TITLE
Making CompletionItem.kind public

### DIFF
--- a/editor/src/main/java/io/github/rosemoe/sora/lang/completion/CompletionItem.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/lang/completion/CompletionItem.java
@@ -68,7 +68,7 @@ public abstract class CompletionItem {
      * an icon is chosen by the editor.
      */
     @Nullable
-    protected CompletionItemKind kind;
+    public CompletionItemKind kind;
 
     /**
      * Use for default sort


### PR DESCRIPTION
I think that it should be public to be able to use custom icon on custom completion adapter depending on item's kind.
Just like CompletionItem.label or CompletionItem.desc.