### PR TITLE
refactor(language-lsp): improve signature help trigger, basic diagnostics support 

### DIFF
--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/client/DefaultLanguageClient.kt
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/client/DefaultLanguageClient.kt
@@ -69,7 +69,7 @@ open class DefaultLanguageClient(protected val context: ClientContext) :
     }
 
     override fun registerCapability(params: RegistrationParams): CompletableFuture<Void> {
-        //Not prepared to support this feature
+        // Not prepared to support this feature
         return CompletableFuture.completedFuture(null)
     }
 
@@ -83,8 +83,6 @@ open class DefaultLanguageClient(protected val context: ClientContext) :
     }
 
     override fun publishDiagnostics(publishDiagnosticsParams: PublishDiagnosticsParams) {
-        // FIXME: support it.
-
         val diagnosticsContainer = context.project.diagnosticsContainer
         val uri = URI(publishDiagnosticsParams.uri).toFileUri()
 
@@ -96,7 +94,6 @@ open class DefaultLanguageClient(protected val context: ClientContext) :
         val editor = context.getEditor(uri)
 
         editor?.onDiagnosticsUpdate()
-
     }
 
     override fun refreshDiagnostics(): CompletableFuture<Void> {

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/client/connection/CustomConnectProvider.kt
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/client/connection/CustomConnectProvider.kt
@@ -62,7 +62,7 @@ class CustomConnectProvider(private val streamProvider: StreamProvider) : Stream
     /**
      * Provider of language server connection
      */
-    interface StreamProvider {
+    fun interface StreamProvider {
         @WorkerThread
         fun getStreams(): Pair<InputStream, OutputStream>
     }

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/client/languageserver/requestmanager/DefaultRequestManager.kt
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/client/languageserver/requestmanager/DefaultRequestManager.kt
@@ -49,6 +49,8 @@ import org.eclipse.lsp4j.DidCloseTextDocumentParams
 import org.eclipse.lsp4j.DidOpenTextDocumentParams
 import org.eclipse.lsp4j.DidSaveTextDocumentParams
 import org.eclipse.lsp4j.DocumentColorParams
+import org.eclipse.lsp4j.DocumentDiagnosticParams
+import org.eclipse.lsp4j.DocumentDiagnosticReport
 import org.eclipse.lsp4j.DocumentFormattingParams
 import org.eclipse.lsp4j.DocumentHighlight
 import org.eclipse.lsp4j.DocumentHighlightParams
@@ -482,6 +484,19 @@ class DefaultRequestManager(
         return if (checkStatus()) {
             try {
                 if (serverCapabilities.documentOnTypeFormattingProvider != null) textDocumentService.onTypeFormatting(
+                    params
+                ) else null
+            } catch (e: Exception) {
+                crashed(e)
+                null
+            }
+        } else null
+    }
+
+    override fun diagnostic(params: DocumentDiagnosticParams?): CompletableFuture<DocumentDiagnosticReport?>? {
+        return if (checkStatus()) {
+            try {
+                if (serverCapabilities.diagnosticProvider != null) textDocumentService.diagnostic(
                     params
                 ) else null
             } catch (e: Exception) {

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/editor/LspEditor.kt
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/editor/LspEditor.kt
@@ -46,6 +46,7 @@ import io.github.rosemoe.sora.lsp.utils.clearVersions
 import io.github.rosemoe.sora.widget.CodeEditor
 import io.github.rosemoe.sora.widget.subscribeEvent
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.future.future
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
@@ -224,9 +225,7 @@ class LspEditor(
                 exception.printStackTrace();
             }
             start = System.currentTimeMillis()
-            withContext(Dispatchers.IO) {
-                Thread.sleep((retryTime / 10).toLong())
-            }
+            delay((retryTime / 10).toLong())
         }
 
         if (!isConnected && start > maxRetryTime) {

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/editor/LspLanguage.kt
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/editor/LspLanguage.kt
@@ -96,7 +96,7 @@ class LspLanguage(var editor: LspEditor) : Language {
         }*/
 
         val prefix = computePrefix(content, position)
-        Log.d("prefix", prefix);
+
         val prefixLength = prefix.length
 
         val documentChangeEvent =

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/editor/completion/LspCompletionItem.kt
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/editor/completion/LspCompletionItem.kt
@@ -24,6 +24,7 @@
 
 package io.github.rosemoe.sora.lsp.editor.completion
 
+import android.util.Log
 import io.github.rosemoe.sora.lang.completion.CompletionItemKind
 import io.github.rosemoe.sora.lang.completion.SimpleCompletionIconDrawer.draw
 import io.github.rosemoe.sora.lang.completion.snippet.parser.CodeSnippetParser

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/editor/event/LspEditorContentChangeEventReceiver.kt
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/editor/event/LspEditorContentChangeEventReceiver.kt
@@ -26,6 +26,7 @@ package io.github.rosemoe.sora.lsp.editor.event
 
 import io.github.rosemoe.sora.event.ContentChangeEvent
 import io.github.rosemoe.sora.event.EventReceiver
+import io.github.rosemoe.sora.event.SelectionChangeEvent
 import io.github.rosemoe.sora.event.Unsubscribe
 import io.github.rosemoe.sora.lsp.editor.LspEditor
 import io.github.rosemoe.sora.lsp.events.EventType
@@ -55,3 +56,19 @@ class LspEditorContentChangeEventReceiver(private val editor: LspEditor) :
     }
 }
 
+class LspEditorSelectionChangeEventReceiver(private val editor: LspEditor): EventReceiver<SelectionChangeEvent> {
+    override fun onReceive(event: SelectionChangeEvent, unsubscribe: Unsubscribe) {
+
+        editor.coroutineScope.launch(Dispatchers.IO) {
+
+            if (editor.hitReTrigger(event.editor.text[event.left.index].toString())) {
+                editor.showSignatureHelp(null)
+                return@launch
+            }
+
+            editor.eventManager.emitAsync(EventType.signatureHelp, event.left)
+        }
+
+
+    }
+}

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/events/EventEmitter.kt
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/events/EventEmitter.kt
@@ -161,7 +161,7 @@ class EventContext {
     }
 
     fun <T : Any> getOrNull(key: String): T? {
-        return data[key] as T?
+        return data[key] as? T?
     }
 
     fun put(key: String, value: Any) {

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/events/diagnostics/PublishDiagnosticsEvent.kt
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/events/diagnostics/PublishDiagnosticsEvent.kt
@@ -40,7 +40,7 @@ class PublishDiagnosticsEvent : EventListener {
 
         val lspEditor = context.get<LspEditor>("lsp-editor")
         val originEditor = lspEditor.editor ?: return
-        val data = context.get<List<Diagnostic>>("data")
+        val data = context.getOrNull<List<Diagnostic>>("data") ?: return
 
         val diagnosticsContainer =
             originEditor.diagnostics ?: DiagnosticsContainer()

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/events/diagnostics/PublishDiagnosticsEvent.kt
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/events/diagnostics/PublishDiagnosticsEvent.kt
@@ -51,7 +51,10 @@ class PublishDiagnosticsEvent : EventListener {
             data.transformToEditorDiagnostics(originEditor)
         )
 
-        originEditor.diagnostics = diagnosticsContainer
+        // run on ui thread
+        originEditor.post {
+            originEditor.diagnostics = diagnosticsContainer
+        }
     }
 
 

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/events/diagnostics/QueryDocumentDiagnosticsEvent.kt
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/events/diagnostics/QueryDocumentDiagnosticsEvent.kt
@@ -48,22 +48,10 @@ class QueryDocumentDiagnosticsEvent : AsyncEventListener() {
             .diagnostic(
                 editor.uri.createDocumentDiagnosticParams()
             )
-            .thenApply { either: DocumentDiagnosticReport ->
-                if (either.isRelatedFullDocumentDiagnosticReport)
-                    either.relatedFullDocumentDiagnosticReport
-                        .relatedDocuments
-                else
-                    either.relatedUnchangedDocumentDiagnosticReport
-                        .relatedDocuments
-            }
 
         this.future = future.thenAccept { }
 
-        val result = future.await()
-
-        if (result.isEmpty()) {
-            return
-        }
+        val result = future.await() ?: return
 
         context.put("diagnostics", result)
     }


### PR DESCRIPTION
- Improve the signature help trigger logic by adding support for triggering it when the selection changes and the character at the selection's left boundary matches a specific condition.
- Adjust thread usage in LspEditor to ensure that the `sleep` operation is performed on a background thread using `Dispatchers.IO`.
- Remove the `FIXME` comment in DefaultLanguageClient, as the support for diagnostics is now implemented.
- Change the `StreamProvider` interface in CustomConnectProvider to a functional interface, simplifying its usage and improving code readability.
- Implemented diagnostic request and publishing logic within the event handling mechanism.
- Updated the request manager to support diagnostic requests.
- Adjusted event data handling for diagnostics to improve type safety and clarity.