### PR TITLE
Disable desugaring. It's not needed anymore.

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -56,9 +56,6 @@ android {
             proguardFiles("proguard-rules.pro")
         }
     }
-    compileOptions {
-        isCoreLibraryDesugaringEnabled = true
-    }
     androidResources {
         additionalParameters.add("--warn-manifest-validation")
     }
@@ -82,9 +79,6 @@ android {
 dependencies {
     implementation(libs.androidx.constraintlayout)
     implementation(libs.gms.instantapps)
-
-    // Desugar
-    coreLibraryDesugaring(libs.desugar)
 
     // androidx & material
     implementation(libs.material)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,6 @@ androidx-core-ktx = { module = "androidx.core:core-ktx", version = "1.13.1" }
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version = "1.7.0" }
 androidx-test-junit = { module = "androidx.test.ext:junit", version = "1.2.1" }
 androidx-test-espresso = { module = "androidx.test.espresso:espresso-core", version = "3.6.1" }
-desugar = { module = "com.android.tools:desugar_jdk_libs", version = "2.1.3" }
 kotlinx-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version = "1.8.0" }
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
 lifecycle-runtime = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version = "2.8.6" }

--- a/language-textmate/build.gradle.kts
+++ b/language-textmate/build.gradle.kts
@@ -49,15 +49,9 @@ android {
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
         }
     }
-    compileOptions {
-        // Flag to enable support for the new language APIs
-        isCoreLibraryDesugaringEnabled = true
-    }
 }
 
 dependencies {
-    coreLibraryDesugaring(libs.desugar)
-
     compileOnly(projects.editor)
     implementation(libs.gson)
     implementation(libs.jcodings)


### PR DESCRIPTION
Hello,

I believe that desugaring is not needed anymore.
It was enabled because tm4e was using toArray(T::new) (Introduced on API 33) but @dingyi222666 replaced it with toArray(new T[0]) which works even before API 33 so this PR disable desugaring.

Also please correct me if i am wrong.

Have a nice day!