### PR TITLE
Disable desugaring on language-textmate module (ONLY)

### DIFF
--- a/language-textmate/build.gradle.kts
+++ b/language-textmate/build.gradle.kts
@@ -51,13 +51,12 @@ android {
     }
     compileOptions {
         // Flag to enable support for the new language APIs
-        isCoreLibraryDesugaringEnabled = true
+        // It's only needed if your app targets old Android APIs.
+        //isCoreLibraryDesugaringEnabled = true
     }
 }
 
 dependencies {
-    coreLibraryDesugaring(libs.desugar)
-
     compileOnly(projects.editor)
     implementation(libs.gson)
     implementation(libs.jcodings)


### PR DESCRIPTION
Disable desugaring on language-textmate module (Only)
while at the same time keep it on sora editor app. So that Applications using language-textmate can disable desugaring if they target only new apis.