### PR TITLE
Fix sticky text selection magnifier

### DIFF
--- a/editor/src/main/java/io/github/rosemoe/sora/widget/EditorTouchEventHandler.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/EditorTouchEventHandler.java
@@ -302,7 +302,7 @@ public final class EditorTouchEventHandler implements GestureDetector.OnGestureL
         var height = pos.height();
         int x, y;
         if (editor.isStickyTextSelection()) {
-            x = (int) (Math.abs(pos.left - e.getX()) > editor.getRowHeight() ? pos.left : e.getX());
+            x = Math.min((int) e.getX(), (int) pos.right);
             y = (int) (pos.top - height / 2);
         } else {
             x = (int) e.getX();


### PR DESCRIPTION
Fixes magnifier position when slowly moving the handle with sticky text selection enabled

**Before:**

https://github.com/user-attachments/assets/a4b5537c-5c82-44ba-96ca-5e7bc9575f65

**After:**

https://github.com/user-attachments/assets/01456e34-df33-4f7d-b0c6-217d82fb56e6