### PR TITLE
Scroll position in content

### DIFF
--- a/editor/src/main/java/io/github/rosemoe/sora/text/Content.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/text/Content.java
@@ -60,6 +60,8 @@ public class Content implements CharSequence {
     private final ReadWriteLock lock;
     private int textLength;
     private int nestedBatchEdit;
+    private int scrollX;
+    private int scrollY;
     private final AtomicLong documentVersion = new AtomicLong(1L);
     private final Indexer indexer;
     private final ContentBidi bidi;
@@ -98,6 +100,8 @@ public class Content implements CharSequence {
         }
         textLength = 0;
         nestedBatchEdit = 0;
+        scrollX = 0;
+        scrollY = 0;
         lines = new ArrayList<>(getInitialLineCapacity());
         lines.add(new ContentLine());
         contentListeners = new ArrayList<>();
@@ -1001,6 +1005,34 @@ public class Content implements CharSequence {
      */
     public boolean isCursorCreated() {
         return cursor != null;
+    }
+
+    /**
+     * Get horizontal scroll position of editor
+     */
+    public int getScrollX() {
+        return scrollX;
+    }
+
+    /**
+     * Get vertical scroll position of editor
+     */
+    public int getScrollY() {
+        return scrollY;
+    }
+
+    /**
+     * Set horizontal scroll position. This does not affect the editor.
+     */
+    public void setScrollX(int scrollX) {
+        this.scrollX = scrollX;
+    }
+
+    /**
+     * Set vertical scroll position. This does not affect the editor.
+     */
+    public void setScrollY(int scrollY) {
+        this.scrollY = scrollY;
     }
 
     /**

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/CodeEditor.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/CodeEditor.java
@@ -4846,6 +4846,13 @@ public class CodeEditor extends View implements ContentListener, Formatter.Forma
     }
 
     @Override
+    protected void onScrollChanged(int l, int t, int oldl, int oldt) {
+        super.onScrollChanged(l, t, oldl, oldt);
+        text.setScrollX(l);
+        text.setScrollY(t);
+    }
+
+    @Override
     protected void onDetachedFromWindow() {
         super.onDetachedFromWindow();
         dispatchEvent(new EditorAttachStateChangeEvent(this, false));

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/EditorTouchEventHandler.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/EditorTouchEventHandler.java
@@ -302,7 +302,7 @@ public final class EditorTouchEventHandler implements GestureDetector.OnGestureL
         var height = pos.height();
         int x, y;
         if (editor.isStickyTextSelection()) {
-            x = (int) (Math.abs(pos.left - e.getX()) > editor.getRowHeight() ? pos.left : e.getX());
+            x = Math.min((int) e.getX(), (int) pos.right);
             y = (int) (pos.top - height / 2);
         } else {
             x = (int) e.getX();


### PR DESCRIPTION
I'm not sure if it's a good decision to have scroll position in `Content` in terms of architecture, but in my case it works well.

I want to be able to save the scroll position in the database so that when I reopen the app, the file will automatically be opened at the previous scroll position. I've already tested this behavior in my app and it works well ([commit](https://github.com/massivemadness/Squircle-CE/commit/f97c80a0ba601fd68d3c72e482572a5e44fa1224#diff-c0a3eb35fb32f3bb9c4a7a3fba4d4932b9660f9a135efedf29ae9097250bc9dd))