### PR TITLE
Fix current line being highlighted when property is disabled

### DIFF
--- a/editor/src/main/java/io/github/rosemoe/sora/widget/EditorRenderer.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/EditorRenderer.java
@@ -591,7 +591,7 @@ public class EditorRenderer {
             drawLineNumberBackground(canvas, offsetX, lineNumberWidth + sideIconWidth + editor.getDividerMarginLeft(), color.getColor(EditorColorScheme.LINE_NUMBER_BACKGROUND));
             int lineNumberColor = editor.getColorScheme().getColor(EditorColorScheme.LINE_NUMBER);
             int currentLineBgColor = editor.getColorScheme().getColor(EditorColorScheme.CURRENT_LINE);
-            if (editor.getCursorAnimator().isRunning() && editor.isEditable()) {
+            if (editor.getCursorAnimator().isRunning() && editor.isHighlightCurrentLine() && editor.isEditable()) {
                 tmpRect.bottom = editor.getCursorAnimator().animatedLineBottom() - editor.getOffsetY();
                 tmpRect.top = tmpRect.bottom - editor.getCursorAnimator().animatedLineHeight();
                 tmpRect.left = 0;
@@ -672,7 +672,7 @@ public class EditorRenderer {
             canvas.clipRect(0, stuckLineCount * editor.getRowHeight(), editor.getWidth(), editor.getHeight());
             int lineNumberColor = editor.getColorScheme().getColor(EditorColorScheme.LINE_NUMBER);
             int currentLineBgColor = editor.getColorScheme().getColor(EditorColorScheme.CURRENT_LINE);
-            if (editor.getCursorAnimator().isRunning() && editor.isEditable()) {
+            if (editor.getCursorAnimator().isRunning() && editor.isHighlightCurrentLine() && editor.isEditable()) {
                 tmpRect.bottom = editor.getCursorAnimator().animatedLineBottom() - editor.getOffsetY();
                 tmpRect.top = tmpRect.bottom - editor.getCursorAnimator().animatedLineHeight();
                 tmpRect.left = 0;
@@ -739,7 +739,7 @@ public class EditorRenderer {
                 tmpRect.bottom = editor.getRowBottom(i) - offsetY - editor.getDpUnit();
                 tmpRect.left = editor.isLineNumberPinned() ? 0 : offset;
                 tmpRect.right = tmpRect.left + editor.measureTextRegionOffset();
-                if (currentLine == line)
+                if (currentLine == line && editor.isHighlightCurrentLine())
                     drawColor(canvas, editor.getColorScheme().getColor(EditorColorScheme.CURRENT_LINE), tmpRect);
                 if (color != 0)
                     drawColor(canvas, color, tmpRect);
@@ -770,7 +770,7 @@ public class EditorRenderer {
                 tmpRect.left = offset;
                 tmpRect.right = editor.getWidth();
                 var colorId = EditorColorScheme.WHOLE_BACKGROUND;
-                if (block.startLine == currentLine) {
+                if (block.startLine == currentLine && editor.isHighlightCurrentLine()) {
                     colorId = EditorColorScheme.CURRENT_LINE;
                 }
                 drawColor(canvas, editor.getColorScheme().getColor(colorId), tmpRect);
@@ -1146,7 +1146,7 @@ public class EditorRenderer {
         // Step 1 - Draw background of rows
 
         // Draw current line background on animation
-        if (editor.getCursorAnimator().isRunning()) {
+        if (editor.getCursorAnimator().isRunning() && editor.isHighlightCurrentLine()) {
             tmpRect.bottom = editor.getCursorAnimator().animatedLineBottom() - editor.getOffsetY();
             tmpRect.top = tmpRect.bottom - editor.getCursorAnimator().animatedLineHeight();
             tmpRect.left = 0;
@@ -1167,7 +1167,10 @@ public class EditorRenderer {
             long charPos = findDesiredVisibleChar(offset3, line, rowInf.startColumn, rowInf.endColumn);
             float paintingOffset = CharPosDesc.getPixelWidthOrOffset(charPos) - offset2;
 
-            var drawCurrentLineBg = line == currentLine && !editor.getCursorAnimator().isRunning() && editor.isEditable();
+            var drawCurrentLineBg = line == currentLine &&
+                    !editor.getCursorAnimator().isRunning() &&
+                    editor.isHighlightCurrentLine() &&
+                    editor.isEditable();
             if (!drawCurrentLineBg || editor.getProps().drawCustomLineBgOnCurrentLine) {
                 // Draw custom background
                 var customBackground = getUserBackgroundForLine(line);

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/EditorTouchEventHandler.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/EditorTouchEventHandler.java
@@ -302,7 +302,7 @@ public final class EditorTouchEventHandler implements GestureDetector.OnGestureL
         var height = pos.height();
         int x, y;
         if (editor.isStickyTextSelection()) {
-            x = (int) (Math.abs(pos.left - e.getX()) > editor.getRowHeight() ? pos.left : e.getX());
+            x = Math.min((int) e.getX(), (int) pos.right);
             y = (int) (pos.top - height / 2);
         } else {
             x = (int) e.getX();


### PR DESCRIPTION
Currently, `EditorRenderer` always rendering current line background, even if `isHighlightCurrentLine` is set to `false`