### PR TITLE
Fix bold matching delimiters

### DIFF
--- a/editor/src/main/java/io/github/rosemoe/sora/widget/EditorRenderer.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/EditorRenderer.java
@@ -2333,8 +2333,11 @@ public class EditorRenderer {
     protected void patchTextRegionWithColor(Canvas canvas, float textOffset, int start, int end, int color, int backgroundColor, int underlineColor) {
         paintGeneral.setColor(color);
         paintOther.setStrokeWidth(editor.getRowHeightOfText() * RenderingConstants.MATCHING_DELIMITERS_UNDERLINE_WIDTH_FACTOR);
-        paintGeneral.setStyle(android.graphics.Paint.Style.FILL_AND_STROKE);
-        paintGeneral.setFakeBoldText(editor.getProps().boldMatchingDelimiters);
+        
+        var useBoldStyle = editor.getProps().boldMatchingDelimiters;
+        paintGeneral.setStyle(useBoldStyle ? Paint.Style.FILL_AND_STROKE : Paint.Style.FILL);
+        paintGeneral.setFakeBoldText(useBoldStyle);
+
         var positions = getTextRegionPositions(start, end);
         patchTextRegions(canvas, textOffset, positions, (canvasLocal, horizontalOffset, row, line, startCol, endCol, style) -> {
             if (backgroundColor != 0) {


### PR DESCRIPTION
Changes paint style from `FILL_AND_STROKE` to `FILL` if `DirectAccessProps.boldMatchingDelimiters` is true

### Before
![before](https://github.com/user-attachments/assets/1a5f2952-0f18-433f-a324-75f31d903926)

### After
![after](https://github.com/user-attachments/assets/c3913c85-fa40-429d-8c15-3c45002fd351)

