### PR TITLE
Set stroke width to 1 dp

### DIFF
--- a/editor/src/main/java/io/github/rosemoe/sora/widget/component/DefaultCompletionLayout.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/component/DefaultCompletionLayout.java
@@ -83,7 +83,7 @@ public class DefaultCompletionLayout implements CompletionLayout {
             });
             rootView.setLayoutTransition(transition);
             listView.setLayoutTransition(transition);
-        } else  {
+        } else {
             rootView.setLayoutTransition(null);
             listView.setLayoutTransition(null);
         }
@@ -132,7 +132,6 @@ public class DefaultCompletionLayout implements CompletionLayout {
         });
 
 
-
         return rootLayout;
     }
 
@@ -140,7 +139,10 @@ public class DefaultCompletionLayout implements CompletionLayout {
     public void onApplyColorScheme(@NonNull EditorColorScheme colorScheme) {
         GradientDrawable gd = new GradientDrawable();
         gd.setCornerRadius(TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 8, editorAutoCompletion.getContext().getResources().getDisplayMetrics()));
-        gd.setStroke(1, colorScheme.getColor(EditorColorScheme.COMPLETION_WND_CORNER));
+        gd.setStroke(
+                (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 1, editorAutoCompletion.getContext().getResources().getDisplayMetrics()),
+                colorScheme.getColor(EditorColorScheme.COMPLETION_WND_CORNER)
+        );
         gd.setColor(colorScheme.getColor(EditorColorScheme.COMPLETION_WND_BACKGROUND));
         rootView.setBackground(gd);
 


### PR DESCRIPTION
Changed stroke width of completion window from 1px to 1dp. This is a small but noticeable difference

Before / After:

![before](https://github.com/user-attachments/assets/e99e2042-e987-4cd6-9a1b-1b4f720eb9fd)

![after](https://github.com/user-attachments/assets/760c41b6-742b-48c8-8ca4-4e53a36d019c)
