### PR TITLE
Fix Zip Slip Vulnerability in Asset Extraction

### DIFF
--- a/app/src/main/java/io/github/rosemoe/sora/app/LspTestJavaActivity.java
+++ b/app/src/main/java/io/github/rosemoe/sora/app/LspTestJavaActivity.java
@@ -315,6 +315,8 @@ public class LspTestJavaActivity extends AppCompatActivity {
                 InputStream inputStream = zipFile.getInputStream(zipEntry);
                 //The compiler will be optimized here, don't worry
                 File filePath = new File(getExternalCacheDir(), fileName.substring("assets/".length()));
+                // SECURITY FIX: Validate that the file path is within the target directory
+                ensureZipPathSafety(filePath, getExternalCacheDir());
                 filePath.getParentFile().mkdirs();
                 FileOutputStream outputStream = new FileOutputStream(filePath);
 


### PR DESCRIPTION
## Summary
Fixed a critical **Zip Slip vulnerability (CWE-22)** in the `unAssets()` method that could allow path traversal attacks during zip file extraction. This allows malicious zip files to contain entries like `../../../sensitive_file` that could write files outside the intended directory.

## Security Fix
- **Added path validation**: Implemented `ensureZipPathSafety()` method to verify extracted files stay within target directory
- **Canonical path checking**: Uses `getCanonicalPath()` to resolve any path traversal attempts
- **Exception handling**: Throws `IOException` for any path traversal attempts

## Changes Made
1. Added `ensureZipPathSafety(filePath, getExternalCacheDir())` call before file extraction
2. Implemented helper method `ensureZipPathSafety()` for path validation
3. Added proper error handling for security violations

References
https://cwe.mitre.org/data/definitions/22.html