### PR TITLE
fix: include motion region and motion bounds with EditorMotionEvent

### DIFF
--- a/editor/src/main/java/io/github/rosemoe/sora/event/ClickEvent.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/event/ClickEvent.java
@@ -41,8 +41,8 @@ import io.github.rosemoe.sora.widget.CodeEditor;
 public class ClickEvent extends EditorMotionEvent {
 
     public ClickEvent(@NonNull CodeEditor editor, @NonNull CharPosition position, @NonNull MotionEvent event,
-                      @Nullable Span span, @Nullable TextRange spanRange) {
-        super(editor, position, event, span, spanRange);
+                      @Nullable Span span, @Nullable TextRange spanRange, int motionRegion, int motionBound) {
+        super(editor, position, event, span, spanRange, motionRegion, motionBound);
     }
 
 }

--- a/editor/src/main/java/io/github/rosemoe/sora/event/DoubleClickEvent.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/event/DoubleClickEvent.java
@@ -42,8 +42,8 @@ import io.github.rosemoe.sora.widget.CodeEditor;
 public class DoubleClickEvent extends EditorMotionEvent {
 
     public DoubleClickEvent(@NonNull CodeEditor editor, @NonNull CharPosition position, @NonNull MotionEvent event,
-                            @Nullable Span span, @Nullable TextRange spanRange) {
-        super(editor, position, event, span, spanRange);
+                            @Nullable Span span, @Nullable TextRange spanRange, int motionRegion, int motionBound) {
+        super(editor, position, event, span, spanRange, motionRegion, motionBound);
     }
 
 }

--- a/editor/src/main/java/io/github/rosemoe/sora/event/EditorMotionEvent.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/event/EditorMotionEvent.java
@@ -33,6 +33,7 @@ import io.github.rosemoe.sora.lang.styling.Span;
 import io.github.rosemoe.sora.text.CharPosition;
 import io.github.rosemoe.sora.text.TextRange;
 import io.github.rosemoe.sora.widget.CodeEditor;
+import io.github.rosemoe.sora.widget.RegionResolverKt;
 
 /**
  * Base class for click events
@@ -44,18 +45,63 @@ import io.github.rosemoe.sora.widget.CodeEditor;
  */
 public abstract class EditorMotionEvent extends Event {
 
+    /**
+     * Motion occurred outside of editor.
+     */
+    public static final int REGION_OUTBOUND = RegionResolverKt.REGION_OUTBOUND;
+
+    /**
+     * Motion occurred in line number region.
+     */
+    public static final int REGION_LINE_NUMBER = RegionResolverKt.REGION_LINE_NUMBER;
+
+    /**
+     * Motion occurred in side icon region.
+     */
+    public static final int REGION_SIDE_ICON = RegionResolverKt.REGION_SIDE_ICON;
+
+    /**
+     * Motion occurred in divider margin region.
+     */
+    public static final int REGION_DIVIDER_MARGIN = RegionResolverKt.REGION_DIVIDER_MARGIN;
+
+    /**
+     * Motion occurred in line divider region.
+     */
+    public static final int REGION_DIVIDER = RegionResolverKt.REGION_DIVIDER;
+
+    /**
+     * Motion occurred in text region.
+     */
+    public static final int REGION_TEXT = RegionResolverKt.REGION_TEXT;
+
+    /**
+     * Motion occurred in editor bounds.
+     */
+    public static final int IN_BOUND = RegionResolverKt.IN_BOUND;
+
+    /**
+     * Motion occurred outside of editor bounds.
+     */
+    public static final int OUT_BOUND = RegionResolverKt.OUT_BOUND;
+
     private final CharPosition pos;
     private final MotionEvent event;
     private final Span span;
     private final TextRange spanRange;
+    private final int motionRegion;
+    private final int motionBound;
 
     public EditorMotionEvent(@NonNull CodeEditor editor, @NonNull CharPosition position,
-                             @NonNull MotionEvent event, @Nullable Span span, @Nullable TextRange spanRange) {
+                             @NonNull MotionEvent event, @Nullable Span span, @Nullable TextRange spanRange,
+                             int motionRegion, int motionBound) {
         super(editor);
         this.pos = position;
         this.event = event;
         this.span = span;
         this.spanRange = spanRange;
+        this.motionRegion = motionRegion;
+        this.motionBound = motionBound;
     }
 
     @Override
@@ -115,4 +161,29 @@ public abstract class EditorMotionEvent extends Event {
         return spanRange;
     }
 
+    /**
+     * Get the region within editor where the motion event occurred.
+     *
+     * @return The region within editor where the motion event occurred.
+     * @see #REGION_OUTBOUND
+     * @see #REGION_LINE_NUMBER
+     * @see #REGION_SIDE_ICON
+     * @see #REGION_DIVIDER_MARGIN
+     * @see #REGION_DIVIDER
+     * @see #REGION_TEXT
+     */
+    public int getMotionRegion() {
+        return motionRegion;
+    }
+
+    /**
+     * Get the bound of the motion event.
+     *
+     * @return The bound of the motion event.
+     * @see #IN_BOUND
+     * @see #OUT_BOUND
+     */
+    public int getMotionBound() {
+        return motionBound;
+    }
 }

--- a/editor/src/main/java/io/github/rosemoe/sora/event/EditorMotionEvent.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/event/EditorMotionEvent.java
@@ -42,46 +42,64 @@ import io.github.rosemoe.sora.widget.RegionResolverKt;
  * @see ClickEvent
  * @see DoubleClickEvent
  * @see LongPressEvent
+ * @see ContextClickEvent
+ * @see HoverEvent
  */
 public abstract class EditorMotionEvent extends Event {
 
     /**
      * Motion occurred outside of editor.
+     *
+     * @see EditorMotionEvent#getMotionRegion()
      */
     public static final int REGION_OUTBOUND = RegionResolverKt.REGION_OUTBOUND;
 
     /**
      * Motion occurred in line number region.
+     *
+     * @see EditorMotionEvent#getMotionRegion()
      */
     public static final int REGION_LINE_NUMBER = RegionResolverKt.REGION_LINE_NUMBER;
 
     /**
      * Motion occurred in side icon region.
+     *
+     * @see EditorMotionEvent#getMotionRegion()
      */
     public static final int REGION_SIDE_ICON = RegionResolverKt.REGION_SIDE_ICON;
 
     /**
      * Motion occurred in divider margin region.
+     *
+     * @see EditorMotionEvent#getMotionRegion()
      */
     public static final int REGION_DIVIDER_MARGIN = RegionResolverKt.REGION_DIVIDER_MARGIN;
 
     /**
      * Motion occurred in line divider region.
+     *
+     * @see EditorMotionEvent#getMotionRegion()
      */
     public static final int REGION_DIVIDER = RegionResolverKt.REGION_DIVIDER;
 
     /**
      * Motion occurred in text region.
+     *
+     * @see EditorMotionEvent#getMotionRegion()
      */
     public static final int REGION_TEXT = RegionResolverKt.REGION_TEXT;
 
     /**
-     * Motion occurred in editor bounds.
+     * Motion occurred in editor bounds on the Y-axis.
+     *
+     * @see EditorMotionEvent#getMotionRegion()
      */
     public static final int IN_BOUND = RegionResolverKt.IN_BOUND;
 
     /**
-     * Motion occurred outside of editor bounds.
+     * Motion occurred outside of editor bounds on the Y-axis.
+     *
+     * @see EditorMotionEvent#getMotionRegion()
      */
     public static final int OUT_BOUND = RegionResolverKt.OUT_BOUND;
 
@@ -162,7 +180,8 @@ public abstract class EditorMotionEvent extends Event {
     }
 
     /**
-     * Get the region within editor where the motion event occurred.
+     * Get the X-axis region where the motion event occurred. Check
+     * {@link #getMotionBound()} to get the Y-axis bound.
      *
      * @return The region within editor where the motion event occurred.
      * @see #REGION_OUTBOUND
@@ -171,17 +190,20 @@ public abstract class EditorMotionEvent extends Event {
      * @see #REGION_DIVIDER_MARGIN
      * @see #REGION_DIVIDER
      * @see #REGION_TEXT
+     * @see #getMotionBound()
      */
     public int getMotionRegion() {
         return motionRegion;
     }
 
     /**
-     * Get the bound of the motion event.
+     * Get the Y-axis bounds of the motion event. Check {@link #getMotionRegion()} to get the
+     * X-axis region.
      *
      * @return The bound of the motion event.
      * @see #IN_BOUND
      * @see #OUT_BOUND
+     * @see #getMotionRegion()
      */
     public int getMotionBound() {
         return motionBound;

--- a/editor/src/main/java/io/github/rosemoe/sora/event/LongPressEvent.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/event/LongPressEvent.java
@@ -45,8 +45,8 @@ public class LongPressEvent extends EditorMotionEvent {
 
 
     public LongPressEvent(@NonNull CodeEditor editor, @NonNull CharPosition position, @NonNull MotionEvent event,
-                          @Nullable Span span, @Nullable TextRange spanRange) {
-        super(editor, position, event, span, spanRange);
+                          @Nullable Span span, @Nullable TextRange spanRange, int motionRegion, int motionBound) {
+        super(editor, position, event, span, spanRange, motionRegion, motionBound);
     }
 
 }

--- a/editor/src/main/java/io/github/rosemoe/sora/event/editorMinorEvents.kt
+++ b/editor/src/main/java/io/github/rosemoe/sora/event/editorMinorEvents.kt
@@ -97,8 +97,10 @@ class ContextClickEvent(
     position: CharPosition,
     event: MotionEvent,
     span: Span?,
-    spanRange: TextRange?
-) : EditorMotionEvent(editor, position, event, span, spanRange)
+    spanRange: TextRange?,
+    motionRegion: Int,
+    motionBound: Int,
+) : EditorMotionEvent(editor, position, event, span, spanRange, motionRegion, motionBound)
 
 /**
  * Trigger when mouse hover updates
@@ -108,8 +110,10 @@ class HoverEvent(
     position: CharPosition,
     event: MotionEvent,
     span: Span?,
-    spanRange: TextRange?
-) : EditorMotionEvent(editor, position, event, span, spanRange)
+    spanRange: TextRange?,
+    motionRegion: Int,
+    motionBound: Int,
+) : EditorMotionEvent(editor, position, event, span, spanRange, motionRegion, motionBound)
 
 /**
  * Trigger when the editor needs to create context menu


### PR DESCRIPTION
See #678 for more details.

---

I added static fields in `EditorMotionEvent` for regions and region bounds because I believe that the definitions should be in `EditorMotionEvent` class itself, and not within a separate `RegionResolverKt` class (library users shouldn't have to look for the possible values of `motionRegion` and `motionBound`). But since we also have to ensure backwards compatibility, the fields in `EditorMotionEvent` simply delegate to the values in `RegionResolverKt`. If you have anything else in mind for this, just let me know and I'll get it done.