### PR TITLE
fix(editor-lsp): add missing safe call operator

### DIFF
--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/client/languageserver/requestmanager/DefaultRequestManager.kt
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/client/languageserver/requestmanager/DefaultRequestManager.kt
@@ -413,7 +413,7 @@ class DefaultRequestManager(
     override fun references(params: ReferenceParams): CompletableFuture<List<Location?>>? {
         return if (checkStatus()) {
             try {
-                if (serverCapabilities.referencesProvider.left == true || serverCapabilities.referencesProvider.right != null) textDocumentService.references(
+                if (serverCapabilities.referencesProvider?.left == true || serverCapabilities.referencesProvider?.right != null) textDocumentService.references(
                     params
                 ) else null
             } catch (e: Exception) {


### PR DESCRIPTION
Forgot to include this null check in the previous PR (#716)

- Add missing safe call operator for `referencesProvider`