### PR TITLE
Fix: createIncrementTextDocumentContentChangeEvent range on insert

### DIFF
--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/events/document/DocumentChangeEvent.kt
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/events/document/DocumentChangeEvent.kt
@@ -84,10 +84,17 @@ class DocumentChangeEvent : AsyncEventListener() {
         val text = data.changedText.toString()
         return listOf(
             editor.uri.createTextDocumentContentChangeEvent(
-                createRange(
-                    data.changeStart,
-                    data.changeEnd
-                ),
+                if (data.action == ContentChangeEvent.ACTION_DELETE) {
+                    createRange(
+                        data.changeStart,
+                        data.changeEnd
+                    )
+                } else {
+                    createRange(
+                        data.changeStart,
+                        data.changeStart
+                    )
+                },
                 if (data.action == ContentChangeEvent.ACTION_DELETE) "" else text
             )
         )


### PR DESCRIPTION
When testing the LSP on rust-analyzer I found that createTextDocumentContentChangeEvent was not really implemented correctly, causing a desync with the server and the editor. I believe this should fix it, or at least fix ACTION_INSERT. The current implementation acts like replace instead of insert. I think this has to do with that the protocol sees the range as the range that should be replaced, not how large the text is after the operation, so only ACTION_DELETE should delete any text.