### PR TITLE
Fix: EventEmitter may throw exceptions, without anyone catching them

### DIFF
--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/events/EventEmitter.kt
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/events/EventEmitter.kt
@@ -31,6 +31,8 @@ class EventEmitter {
 
     private val listeners = HashMap<String, MutableList<EventListener>>()
 
+    var throwableListener: ((Throwable) -> Unit) = { t -> throw t }
+
     fun addListener(listener: EventListener) {
         listeners.getOrPut(listener.eventName) { ArrayList() }.add(listener)
     }
@@ -56,15 +58,23 @@ class EventEmitter {
     }
 
     fun emit(event: String, context: EventContext): EventContext {
-        listeners[event]?.forEach {
-            it.handle(context)
+        try {
+            listeners[event]?.forEach {
+                it.handle(context)
+            }
+        } catch (t: Throwable) {
+            throwableListener.invoke(t)
         }
         return context
     }
 
     suspend fun emitAsync(event: String, context: EventContext): EventContext {
-        listeners[event]?.forEach {
-            it.handleAsync(context)
+        try {
+            listeners[event]?.forEach {
+                it.handleAsync(context)
+            }
+        } catch (t: Throwable) {
+            throwableListener.invoke(t)
         }
         return context
     }


### PR DESCRIPTION
I am unsure exactly where this should be placed, but right now the EventEmitter will just run events without anyone catching them. This adds an optional `throwableListener` that may handle exceptions/errors as the LSP may throw errors that should not crash the entire app, e.g. https://github.com/neovim/neovim/issues/30985 "server cancelled the request" when typing too fast. 

Another solution may be to better handle exceptions correctly in the handleAsync, but this is my band-aid in the meantime, as every future is not currently in a try catch block. 