### PR TITLE
Fix: null cannot be cast to non-null type T

### DIFF
--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/events/EventEmitter.kt
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/events/EventEmitter.kt
@@ -41,7 +41,7 @@ class EventEmitter {
 
     fun <T : EventListener> getEventListener(clazz: Class<T>): T? {
         return listeners.flatMap { it.value }
-            .find { it::class.java == clazz } as T
+            .find { it::class.java == clazz } as? T?
     }
 
     fun <T : EventListener> removeListener(listenerClass: Class<T>) {


### PR DESCRIPTION
Returns null instead of throwing NullPointerException when the EventListener is not found. 