### PR TITLE
fix(editor-lsp): allow insertion after last character in line

### DIFF
--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/editor/completion/LspCompletionItem.kt
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/editor/completion/LspCompletionItem.kt
@@ -24,7 +24,6 @@
 
 package io.github.rosemoe.sora.lsp.editor.completion
 
-import android.util.Log
 import io.github.rosemoe.sora.lang.completion.CompletionItemKind
 import io.github.rosemoe.sora.lang.completion.SimpleCompletionIconDrawer.draw
 import io.github.rosemoe.sora.lang.completion.snippet.parser.CodeSnippetParser
@@ -116,18 +115,15 @@ class LspCompletionItem(
 
         if (completionItem.insertTextFormat == InsertTextFormat.Snippet) {
             val codeSnippet = CodeSnippetParser.parse(textEdit.newText)
-            var startIndex =
-                text.getCharIndex(
-                    textEdit.range.start.line, textEdit.range.start.character
-                )
+            var startIndex = text.getCharIndex(
+                textEdit.range.start.line,
+                textEdit.range.start.character.coerceAtMost(text.getColumnCount(textEdit.range.start.line))
+            )
 
             var endIndex = text.getCharIndex(
                 textEdit.range.end.line,
-                (text.getColumnCount(textEdit.range.end.line) - 1)
-                    .coerceAtMost(textEdit.range.end.character)
+                textEdit.range.end.character.coerceAtMost(text.getColumnCount(textEdit.range.end.line))
             )
-
-            val selectedText = text.subSequence(startIndex, endIndex).toString()
 
             if (endIndex < startIndex) {
                 Logger.instance(this.javaClass.name)
@@ -140,6 +136,8 @@ class LspCompletionItem(
                 endIndex = startIndex
                 startIndex = endIndex - diff
             }
+
+            val selectedText = text.subSequence(startIndex, endIndex).toString()
 
             text.delete(startIndex, endIndex)
 


### PR DESCRIPTION
This PR closes issue #724 

## Changes
- Move `selectedText` below the `if (endIndex < startIndex)` block to ensure the boundary check acts as a fallback
- Apply `coerceAtMost()` to `startIndex` calculation to ensure maximum boundary is respected
- Remove unnecessary `-1` subtraction from `getColumnCount()`

**NOTE**: I placed the `textEdit.range.start.character` before the `coerceAtMost()` call for better readability and to make the intention clearer.