### PR TITLE
Improve spannable index handling in comparators.kt

### DIFF
--- a/editor/src/main/java/io/github/rosemoe/sora/lang/completion/comparators.kt
+++ b/editor/src/main/java/io/github/rosemoe/sora/lang/completion/comparators.kt
@@ -287,13 +287,25 @@ fun List<CompletionItem>.highlightMatchLabel(colorSchema: EditorColorScheme?): L
 
         for (index in score.matches.indices.reversed()) {
             val matchIndex = score.matches[index]
-            spannable.setSpan(
-                ForegroundColorSpan(matchedColor),
-                matchIndex,
-                spannable.length.coerceAtMost(matchIndex + 1),
-                Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
-            )
+        
+            // Skip invalid indices
+            if (matchIndex < 0 || matchIndex >= spannable.length) continue
+        
+            val end = (matchIndex + 1).coerceAtMost(spannable.length)
+            if (end <= matchIndex) continue
+        
+            try {
+                spannable.setSpan(
+                    ForegroundColorSpan(matchedColor),
+                    matchIndex,
+                    end,
+                    Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
+                )
+            } catch (e: Exception) {
+                e.printStackTrace()
+            }
         }
+
 
         item.label = spannable
 


### PR DESCRIPTION
Refactor spannable color setting to handle invalid indices and exceptions.

I’m not entirely sure about the root cause of this crash, but this change should prevent it from occurring.

```
java.lang.IndexOutOfBoundsException: setSpan (9 ... 7) has end before start
 at android.text.SpannableStringInternal.checkRange(SpannableStringInternal.java:485)
 at android.text.SpannableStringInternal.setSpan(SpannableStringInternal.java:199)
 at android.text.SpannableStringInternal.setSpan(SpannableStringInternal.java:186)
 at android.text.SpannableString.setSpan(SpannableString.java:60)
 at io.github.rosemoe.sora.lang.completion.Comparators.highlightMatchLabel(comparators.kt:290)
 at io.github.rosemoe.sora.widget.component.EditorAutoCompletion.lambda$requireCompletion$6(EditorAutoCompletion.java:560)
 at io.github.rosemoe.sora.widget.component.EditorAutoCompletion.$r8$lambda$Y_ka4KkcIzzn9ZdjGBNKy7ireoc(Unknown Source:0)
 at io.github.rosemoe.sora.widget.component.EditorAutoCompletion$$ExternalSyntheticLambda5.run(D8$$SyntheticClass:0)
 at io.github.rosemoe.sora.lang.completion.CompletionPublisher.lambda$updateList$1(CompletionPublisher.java:254)
 at io.github.rosemoe.sora.lang.completion.CompletionPublisher.$r8$lambda$5EQJVigGWFv9uD2ZsnuFMx3kBCo(Unknown Source:0)
 at io.github.rosemoe.sora.lang.completion.CompletionPublisher$$ExternalSyntheticLambda1.run(D8$$SyntheticClass:0)
```