### PR TITLE
[Fix] Stop scrolling and release edge effects on long press

### DIFF
--- a/editor/src/main/java/io/github/rosemoe/sora/widget/EditorTouchEventHandler.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/EditorTouchEventHandler.java
@@ -895,6 +895,8 @@ public final class EditorTouchEventHandler implements GestureDetector.OnGestureL
 
     @Override
     public void onLongPress(@NonNull MotionEvent e) {
+        scroller.forceFinished(true);
+        editor.releaseEdgeEffects();
         if (editor.isFormatting()) {
             return;
         }


### PR DESCRIPTION
This PR fixes an issue where drag selection could be initiated while the editor is still scrolling or showing edge effects.