### PR TITLE
support 16 KB page size for oniguruma-binding

### DIFF
--- a/oniguruma-native/build.gradle.kts
+++ b/oniguruma-native/build.gradle.kts
@@ -45,7 +45,7 @@ android {
         }
     }
 
-    ndkVersion = "25.1.8937393"
+    ndkVersion = "29.0.14206865"
 
     externalNativeBuild {
         cmake {

--- a/oniguruma-native/src/main/cpp/CMakeLists.txt
+++ b/oniguruma-native/src/main/cpp/CMakeLists.txt
@@ -10,4 +10,3 @@ add_subdirectory(oniguruma)
 add_library("oniguruma-binding" SHARED binding.cpp)
 
 target_link_libraries("oniguruma-binding" PUBLIC onig)
-target_link_options(${CMAKE_PROJECT_NAME} PRIVATE "-Wl,-z,max-page-size=16384")


### PR DESCRIPTION
Starting November 1st, 2025, all new apps and updates to existing apps submitted to Google Play and targeting Android 15+ devices must support 16 KB page sizes.

https://developer.android.com/16kb-page-size.