### PR TITLE
[Feature] Add PublishDiagnosticsEvent for diagnostics changes

### DIFF
--- a/editor/src/main/java/io/github/rosemoe/sora/event/editorMinorEvents.kt
+++ b/editor/src/main/java/io/github/rosemoe/sora/event/editorMinorEvents.kt
@@ -29,6 +29,8 @@ import android.view.ContextMenu
 import android.view.MotionEvent
 import android.view.inputmethod.EditorInfo
 import io.github.rosemoe.sora.lang.Language
+import io.github.rosemoe.sora.lang.diagnostic.DiagnosticDetail
+import io.github.rosemoe.sora.lang.diagnostic.DiagnosticRegion
 import io.github.rosemoe.sora.lang.styling.Span
 import io.github.rosemoe.sora.text.CharPosition
 import io.github.rosemoe.sora.text.TextRange
@@ -160,3 +162,12 @@ class PublishSearchResultEvent(editor: CodeEditor) : Event(editor) {
  * Triggered when the initial layout async task starts/stops
  */
 class LayoutStateChangeEvent(editor: CodeEditor, val isLayoutBusy: Boolean) : Event(editor)
+
+/**
+ * Trigger when the editor diagnostics changed
+ */
+class PublishDiagnosticsEvent(
+    editor: CodeEditor,
+    val oldDiagnostics: List<DiagnosticRegion>,
+    val newDiagnosticsEvent: List<DiagnosticRegion>
+): Event(editor)

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/CodeEditor.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/CodeEditor.java
@@ -968,6 +968,11 @@ public class CodeEditor extends View implements ContentListener, Formatter.Forma
         styleDelegate.reset();
         this.editorLanguage = lang;
         this.textStyles = null;
+
+        if (this.diagnostics != null) {
+            this.diagnostics.detachEditor();
+        }
+
         this.diagnostics = null;
 
         // Setup new one
@@ -4243,7 +4248,15 @@ public class CodeEditor extends View implements ContentListener, Formatter.Forma
 
     @UiThread
     public void setDiagnostics(@Nullable DiagnosticsContainer diagnostics) {
+        if (this.diagnostics != null) {
+            this.diagnostics.detachEditor();
+        }
+
         this.diagnostics = diagnostics;
+
+        if (this.diagnostics != null) {
+            this.diagnostics.attachEditor(this);
+        }
         invalidate();
     }
 


### PR DESCRIPTION
This PR adds a `PublishDiagnosticsEvent` that is triggered when diagnostics are modified in the editor.

## New Features

- Add `PublishDiagnosticsEvent` class with old and new diagnostics lists
- `DiagnosticsContainer` now dispatches events when diagnostics are added or reset
- Add `attachEditor` and `detachEditor` methods to `DiagnosticsContainer` for editor lifecycle management
- `CodeEditor` manages editor reference lifecycle in diagnostics container

## Bug fixes

None

## Other Changes

None

Closes #773