### PR TITLE
fix: fix unnecessary stop of language server wrapper

### DIFF
--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/client/languageserver/wrapper/LanguageServerWrapper.kt
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/client/languageserver/wrapper/LanguageServerWrapper.kt
@@ -425,14 +425,7 @@ class LanguageServerWrapper(
 
         val capabilities = getServerCapabilities()
         if (capabilities == null) {
-            Log.w(
-                TAG,
-                "Capabilities are null for $serverDefinition"
-            )
-            return
-        }
-
-        if (connectedEditors.contains(editor)) {
+            Log.w(TAG, "Capabilities are null for $serverDefinition")
             return
         }
 

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/editor/LspEditorDelegate.kt
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/editor/LspEditorDelegate.kt
@@ -54,17 +54,11 @@ internal class LspEditorDelegate(private val editor: LspEditor) {
         var lastCapabilities: ServerCapabilities? = null
 
         for (info in sessionInfos) {
-            if (info.wrapper.status == ServerStatus.INITIALIZED) {
-                continue
-            }
-
             info.wrapper.start()
             val capabilities = info.wrapper.getServerCapabilities()
 
-            if (capabilities != null) {
-                info.wrapper.connect(editor)
-                lastCapabilities = capabilities
-            }
+            info.wrapper.connect(editor)
+            lastCapabilities = capabilities ?: lastCapabilities
         }
 
         val initializedWrappers = sessionInfos

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/editor/LspProject.kt
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/editor/LspProject.kt
@@ -123,6 +123,10 @@ class LspProject(
         editors.remove(path.toFileUri())
     }
 
+    fun getEditors(): List<LspEditor> {
+        return editors.values.toList()
+    }
+
     fun getEditor(path: String): LspEditor? {
         return editors[path.toFileUri()]
     }
@@ -136,7 +140,7 @@ class LspProject(
     }
 
     fun closeAllEditors() {
-        val editorsSnapshot = editors.values.toList()
+        val editorsSnapshot = getEditors()
         editorsSnapshot.forEach {
             it.dispose()
         }


### PR DESCRIPTION
This pull request fixes the issue where, when starting another editor instance connecting to the same language server, `LanguageServerWrapper#connect(...)` was skipped beforehand. This resulted in the editor being missing in the `connectedEditors` list, and the language server therefore stopping prematurely because it didn't take the unadded editor into account.