### PR TITLE
fix(editor-lsp): completion overlap and character bounds

### DIFF
--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/editor/completion/LspCompletionItem.kt
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/editor/completion/LspCompletionItem.kt
@@ -111,31 +111,57 @@ class LspCompletionItem(
     }
 
     override fun performCompletion(editor: CodeEditor, text: Content, position: CharPosition) {
-        var textEdit = TextEdit()
+        val defaultRange = createRange(
+             createPosition(
+                 position.line,
+                 position.column - prefixLength
+             ),
+             position.asLspPosition()
+         )
 
-        textEdit.range = createRange(
-            createPosition(
-                position.line,
-                position.column - prefixLength
-            ), position.asLspPosition()
-        )
+        val textEdit = when {
+            completionItem.textEdit?.isLeft == true -> {
+                completionItem.textEdit.left
+            }
 
+            completionItem.textEdit?.isRight == true -> {
+                TextEdit(
+                    completionItem.textEdit.right.insert,
+                    completionItem.textEdit.right.newText
+                )
+            }
 
-        if (completionItem.insertText != null) {
-            textEdit.newText = completionItem.insertText
-        }
+            else -> {
+                TextEdit().apply {
+                    range = defaultRange
+                    newText = completionItem.insertText ?: completionItem.label
+                }.also {
+                    // Fix overlap issue, e.g.:
+                    // console.lo| <- cursor
+                    // If label or insertText is console.log it would otherwise result in console.console.log
+                    val lineText = text.getLine(it.range.start.line).toString()
+                    val startChar = it.range.start.character
 
-        if (completionItem.textEdit != null && completionItem.textEdit.isLeft) {
-            textEdit = completionItem.textEdit.left
-        } else if (completionItem.textEdit?.isRight == true) {
-            textEdit = TextEdit(
-                completionItem.textEdit.right.insert,
-                completionItem.textEdit.right.newText
-            )
-        }
+                    val textBefore = if (startChar in 0..lineText.length) {
+                        lineText.substring(0, startChar)
+                    } else {
+                        ""
+                    }
+                    val newText = it.newText
+                    var overlapLength = 0
+                    val maxOverlap = kotlin.math.min(textBefore.length, newText.length)
 
-        if (textEdit.newText == null && completionItem.label != null) {
-            textEdit.newText = completionItem.label
+                    for (i in 1..maxOverlap) {
+                        val suffix = textBefore.substring(textBefore.length - i)
+                        if (newText.startsWith(suffix)) {
+                            overlapLength = i
+                        }
+                    }
+                    if (overlapLength > 0) {
+                        it.range.start.character = startChar - overlapLength
+                    }
+                }
+            }
         }
 
         run {

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/events/document/ApplyEditsEvent.kt
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/events/document/ApplyEditsEvent.kt
@@ -70,7 +70,8 @@ class ApplyEditsEvent : EventListener {
     fun calculateIndices(content: Content, range: Range): Pair<Int, Int> {
         var startIndex = content.getCharIndex(range.start.line, range.start.character)
         val endLine = range.end.line.coerceAtMost(content.lineCount - 1)
-        var endIndex = content.getCharIndex(endLine, range.end.character)
+        val endCharacter = range.end.character.coerceAtMost(content.getColumnCount(endLine))
+        var endIndex = content.getCharIndex(endLine, endCharacter)
 
         if (endIndex < startIndex) {
             Logger.instance(this.javaClass.name).w(

--- a/editor/src/main/java/io/github/rosemoe/sora/lang/styling/StylesUtils.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/lang/styling/StylesUtils.java
@@ -40,7 +40,7 @@ public class StylesUtils {
      */
     public static boolean checkNoCompletion(@Nullable Styles styles, @NonNull CharPosition pos) {
         var span = getSpanForPosition(styles, pos);
-        return span == null || TextStyle.isNoCompletion(span.getStyle());
+        return styles != null && (span == null || TextStyle.isNoCompletion(span.getStyle()));
     }
 
     /**


### PR DESCRIPTION
This PR improves the readability of `performCompletion`. Additionally, instead of replacing the completion result up to the nearest prefix (probably makes computePrefix obselete. I did not remove it, however.), it now searches for overlaps to prevent text duplication.

Furthermore, the `calculateIndices` method has been made more robust to prevent crashes.

The change to `StylesUtils` might be a matter of debate.
The issue I encountered was that the LSP completion window would not appear if the language set in the editor was `EmptyLanguage`. This occurred because the `styles` were `null` in this case; consequently, `getSpanForPosition` also returned `null`, which in turn meant that completion did not work at all as long as no language was defined in the editor. Was this behavior unintentional, @Rosemoe?