### PR TITLE
Fix tmpRect from clobbering LineInfoPanel

### DIFF
--- a/editor/src/main/java/io/github/rosemoe/sora/widget/EditorRenderer.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/EditorRenderer.java
@@ -2141,8 +2141,6 @@ public class EditorRenderer {
         verticalScrollBarRect.set(tmpRect);
         if (editor.getEventHandler().holdVerticalScrollBar()) {
             drawLineInfoPanel(canvas, tmpRect.top, tmpRect.height(), 30 * editor.getDpUnit());
-            getVerticalScrollBarRect(tmpRect, editor.getDpUnit() * RenderingConstants.SCROLLBAR_WIDTH_DIP);
-            verticalScrollBarRect.set(tmpRect);
         }
         if (verticalScrollbarThumbDrawable != null) {
             verticalScrollbarThumbDrawable.setState(editor.getEventHandler().holdVerticalScrollBar() ? PRESSED_DRAWABLE_STATE : DEFAULT_DRAWABLE_STATE);

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/EditorRenderer.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/EditorRenderer.java
@@ -2141,6 +2141,8 @@ public class EditorRenderer {
         verticalScrollBarRect.set(tmpRect);
         if (editor.getEventHandler().holdVerticalScrollBar()) {
             drawLineInfoPanel(canvas, tmpRect.top, tmpRect.height(), 30 * editor.getDpUnit());
+            getVerticalScrollBarRect(tmpRect, editor.getDpUnit() * RenderingConstants.SCROLLBAR_WIDTH_DIP);
+            verticalScrollBarRect.set(tmpRect);
         }
         if (verticalScrollbarThumbDrawable != null) {
             verticalScrollbarThumbDrawable.setState(editor.getEventHandler().holdVerticalScrollBar() ? PRESSED_DRAWABLE_STATE : DEFAULT_DRAWABLE_STATE);
@@ -2149,7 +2151,7 @@ public class EditorRenderer {
                     (int) verticalScrollBarRect.bottom);
             verticalScrollbarThumbDrawable.draw(canvas);
         } else {
-            drawColor(canvas, editor.getColorScheme().getColor(editor.getEventHandler().holdVerticalScrollBar() ? EditorColorScheme.SCROLL_BAR_THUMB_PRESSED : EditorColorScheme.SCROLL_BAR_THUMB), tmpRect);
+            drawColor(canvas, editor.getColorScheme().getColor(editor.getEventHandler().holdVerticalScrollBar() ? EditorColorScheme.SCROLL_BAR_THUMB_PRESSED : EditorColorScheme.SCROLL_BAR_THUMB), verticalScrollBarRect);
         }
     }
 
@@ -2474,10 +2476,10 @@ public class EditorRenderer {
         horizontalScrollBarRect.set(tmpRect);
         if (horizontalScrollbarThumbDrawable != null) {
             horizontalScrollbarThumbDrawable.setState(editor.getEventHandler().holdHorizontalScrollBar() ? PRESSED_DRAWABLE_STATE : DEFAULT_DRAWABLE_STATE);
-            horizontalScrollbarThumbDrawable.setBounds((int) tmpRect.left, (int) tmpRect.top, (int) tmpRect.right, (int) tmpRect.bottom);
+            horizontalScrollbarThumbDrawable.setBounds((int) horizontalScrollBarRect.left, (int) horizontalScrollBarRect.top, (int) horizontalScrollBarRect.right, (int) horizontalScrollBarRect.bottom);
             horizontalScrollbarThumbDrawable.draw(canvas);
         } else {
-            drawColor(canvas, editor.getColorScheme().getColor(editor.getEventHandler().holdHorizontalScrollBar() ? EditorColorScheme.SCROLL_BAR_THUMB_PRESSED : EditorColorScheme.SCROLL_BAR_THUMB), tmpRect);
+            drawColor(canvas, editor.getColorScheme().getColor(editor.getEventHandler().holdHorizontalScrollBar() ? EditorColorScheme.SCROLL_BAR_THUMB_PRESSED : EditorColorScheme.SCROLL_BAR_THUMB), horizontalScrollBarRect);
         }
     }
 


### PR DESCRIPTION
i found that when using sora in jetpack compose it causes the tmpRect to skew into LineInfoPanel's space resulting in a grey block (scrollbar's rect) overlapping with it (presumably because the xml views are null?)