### PR TITLE
feat: support custom timeouts and formatter/styles provider

### DIFF
--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/client/languageserver/requestmanager/AggregatedRequestManager.kt
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/client/languageserver/requestmanager/AggregatedRequestManager.kt
@@ -80,6 +80,7 @@ import org.eclipse.lsp4j.jsonrpc.messages.Either3
 import org.eclipse.lsp4j.services.TextDocumentService
 import org.eclipse.lsp4j.services.WorkspaceService
 import io.github.rosemoe.sora.lsp.utils.merge
+import io.github.rosemoe.sora.lsp.requests.Timeouts
 import java.util.LinkedHashMap
 import java.util.concurrent.CompletableFuture
 
@@ -90,6 +91,11 @@ class AggregatedRequestManager(
     override val serverName = "NO-SERVER"
 
     private var sessionEntries = sessions
+
+    fun getMaximumTimeout(type: Timeouts): Int? {
+        val timeouts = sessionEntries.mapNotNull { it.serverDefinition.customTimeouts[type] }
+        return if (timeouts.isEmpty()) null else timeouts.maxOrNull()
+    }
 
     var activeManagers: List<RequestManager> = sessionEntries.mapNotNull { it.requestManager }
         private set

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/client/languageserver/serverdefinition/LanguageServerDefinition.kt
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/client/languageserver/serverdefinition/LanguageServerDefinition.kt
@@ -28,6 +28,7 @@ import android.util.Log
 import io.github.rosemoe.sora.lsp.client.connection.StreamConnectionProvider
 import io.github.rosemoe.sora.lsp.client.languageserver.LspFeature
 import io.github.rosemoe.sora.lsp.client.languageserver.wrapper.EventHandler
+import io.github.rosemoe.sora.lsp.requests.Timeouts
 
 import org.eclipse.lsp4j.ServerCapabilities
 
@@ -52,6 +53,8 @@ abstract class LanguageServerDefinition {
 
     private val streamConnectionProviders: MutableMap<String, StreamConnectionProvider> =
         ConcurrentHashMap()
+
+    open val customTimeouts: Map<Timeouts, Int> = emptyMap()
 
     open val disabledFeatures: Set<LspFeature> = emptySet()
 

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/client/languageserver/wrapper/LanguageServerWrapper.kt
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/client/languageserver/wrapper/LanguageServerWrapper.kt
@@ -151,7 +151,7 @@ class LanguageServerWrapper(
             start(true)
 
             initializeFuture?.get(
-                if (capabilitiesAlreadyRequested) 0L else Timeout[Timeouts.INIT].toLong(),
+                if (capabilitiesAlreadyRequested) 0L else Timeout[Timeouts.INIT, serverDefinition].toLong(),
                 TimeUnit.MILLISECONDS
             )
         } catch (_: TimeoutException) {
@@ -159,7 +159,7 @@ class LanguageServerWrapper(
                 Locale.getDefault(),
                 "%s \n is not initialized after %d seconds",
                 serverDefinition.toString(),
-                Timeout[Timeouts.INIT] / 1000
+                Timeout[Timeouts.INIT, serverDefinition] / 1000
             )
             Log.w(TAG, msg)
             serverDefinition.eventListener.onHandlerException(LSPException(msg))
@@ -297,7 +297,7 @@ class LanguageServerWrapper(
             try {
                 val shutdown = languageServer?.shutdown()
 
-                shutdown?.get(Timeout[Timeouts.SHUTDOWN].toLong(), TimeUnit.MILLISECONDS)
+                shutdown?.get(Timeout[Timeouts.SHUTDOWN, serverDefinition].toLong(), TimeUnit.MILLISECONDS)
 
                 if (exit && serverDefinition.callExitForLanguageServer()) {
                     languageServer?.exit()
@@ -436,7 +436,7 @@ class LanguageServerWrapper(
             return
         }
 
-        localInitializeFuture.get(Timeout[Timeouts.INIT].toLong(), TimeUnit.MILLISECONDS)
+        localInitializeFuture.get(Timeout[Timeouts.INIT, serverDefinition].toLong(), TimeUnit.MILLISECONDS)
 
         try {
             val syncOptions =

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/editor/LspEditor.kt
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/editor/LspEditor.kt
@@ -255,7 +255,7 @@ class LspEditor(
         var isConnected = false
 
         var start = System.currentTimeMillis()
-        val retryTime = Timeout[Timeouts.INIT]
+        val retryTime = Timeout[Timeouts.INIT, this]
         val maxRetryTime: Long = start + retryTime
 
         while (start < maxRetryTime) {

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/editor/LspLanguage.kt
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/editor/LspLanguage.kt
@@ -109,7 +109,7 @@ class LspLanguage(var editor: LspEditor) : Language {
 
         if (documentChangeFuture?.isDone == false || documentChangeFuture?.isCompletedExceptionally == false || documentChangeFuture?.isCancelled == false) {
             runCatching {
-                documentChangeFuture.get(Timeout[Timeouts.WILLSAVE].toLong(), TimeUnit.MILLISECONDS)
+                documentChangeFuture.get(Timeout[Timeouts.WILLSAVE, editor].toLong(), TimeUnit.MILLISECONDS)
             }
         }
 
@@ -137,7 +137,7 @@ class LspLanguage(var editor: LspEditor) : Language {
                 }.exceptionally { throwable: Throwable ->
                     publisher.cancel()
                     throw CompletionCancelledException(throwable.message)
-                }.get(Timeout[Timeouts.COMPLETION].toLong(), TimeUnit.MILLISECONDS)
+                }.get(Timeout[Timeouts.COMPLETION, editor].toLong(), TimeUnit.MILLISECONDS)
         } catch (e: InterruptedException) {
             return
         }

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/events/code/CodeActionEvent.kt
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/events/code/CodeActionEvent.kt
@@ -71,7 +71,7 @@ class CodeActionEvent : AsyncEventListener() {
 
         var codeActions: List<Either<Command, CodeAction>>? = null
 
-        withTimeout(Timeout[Timeouts.CODEACTION].toLong()) {
+        withTimeout(Timeout[Timeouts.CODEACTION, editor].toLong()) {
             codeActions =
                 future.await() ?: emptyList()
         }

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/events/color/DocumentColor.kt
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/events/color/DocumentColor.kt
@@ -114,7 +114,7 @@ class DocumentColorEvent : AsyncEventListener() {
             val documentColors: List<ColorInformation>?
 
             try {
-                withTimeout(Timeout[Timeouts.DOC_HIGHLIGHT].toLong()) {
+                withTimeout(Timeout[Timeouts.DOC_HIGHLIGHT, editor].toLong()) {
                     documentColors =
                         future.await()
                 }

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/events/format/FullFormattingEvent.kt
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/events/format/FullFormattingEvent.kt
@@ -66,7 +66,7 @@ class FullFormattingEvent : AsyncEventListener() {
 
         val textEditList: List<TextEdit>
 
-        withTimeout(Timeout[Timeouts.FORMATTING].toLong()) {
+        withTimeout(Timeout[Timeouts.FORMATTING, editor].toLong()) {
             textEditList = formattingFuture.await() ?: listOf()
         }
 

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/events/format/RangeFormattingEvent.kt
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/events/format/RangeFormattingEvent.kt
@@ -70,7 +70,7 @@ class RangeFormattingEvent : AsyncEventListener() {
 
         val textEditList: List<TextEdit>
 
-        withTimeout(Timeout[Timeouts.FORMATTING].toLong()) {
+        withTimeout(Timeout[Timeouts.FORMATTING, editor].toLong()) {
             textEditList = formattingFuture.await() ?: listOf()
         }
 

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/events/highlight/DocumentHighlightEvent.kt
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/events/highlight/DocumentHighlightEvent.kt
@@ -70,7 +70,7 @@ class DocumentHighlightEvent : AsyncEventListener() {
 
         val documentHighlights: List<DocumentHighlight>?
 
-        withTimeout(Timeout[Timeouts.DOC_HIGHLIGHT].toLong()) {
+        withTimeout(Timeout[Timeouts.DOC_HIGHLIGHT, editor].toLong()) {
             documentHighlights = future.await()
         }
 

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/events/hover/HoverEvent.kt
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/events/hover/HoverEvent.kt
@@ -66,7 +66,7 @@ class HoverEvent : AsyncEventListener() {
 
         val hover: Hover?
 
-        withTimeout(Timeout[Timeouts.HOVER].toLong()) {
+        withTimeout(Timeout[Timeouts.HOVER, editor].toLong()) {
             hover = future.await()
         }
 

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/events/inlayhint/InlayHintEvent.kt
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/events/inlayhint/InlayHintEvent.kt
@@ -135,7 +135,7 @@ class InlayHintEvent : AsyncEventListener() {
             val inlayHints: List<InlayHint>?
 
             try {
-                withTimeout(Timeout[Timeouts.INLAY_HINT].toLong()) {
+                withTimeout(Timeout[Timeouts.INLAY_HINT, editor].toLong()) {
                     inlayHints = future.await()
                 }
             } catch (e: Exception) {

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/events/signature/SignatureHelpEvent.kt
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/events/signature/SignatureHelpEvent.kt
@@ -66,7 +66,7 @@ class SignatureHelpEvent : AsyncEventListener() {
 
         val signatureHelp: SignatureHelp?
 
-        withTimeout(Timeout[Timeouts.SIGNATURE].toLong()) {
+        withTimeout(Timeout[Timeouts.SIGNATURE, editor].toLong()) {
             signatureHelp =
                 future.await()
         }

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/events/workspace/WorkSpaceExecuteCommand.kt
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/events/workspace/WorkSpaceExecuteCommand.kt
@@ -55,7 +55,7 @@ class WorkSpaceExecuteCommand : AsyncEventListener() {
 
         val result: Any?
 
-        withTimeout(Timeout[Timeouts.EXECUTE_COMMAND].toLong()) {
+        withTimeout(Timeout[Timeouts.EXECUTE_COMMAND, editor].toLong()) {
             result =
                 future?.await()
         }

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/requests/Timeout.kt
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/requests/Timeout.kt
@@ -24,6 +24,8 @@
 
 package io.github.rosemoe.sora.lsp.requests
 
+import io.github.rosemoe.sora.lsp.client.languageserver.serverdefinition.LanguageServerDefinition
+import io.github.rosemoe.sora.lsp.editor.LspEditor
 import java.util.concurrent.ConcurrentHashMap
 
 
@@ -63,6 +65,22 @@ object Timeout {
      */
     operator fun get(type: Timeouts): Int {
         return timeouts[type] ?: type.defaultTimeout
+    }
+
+    /**
+     * Get the timeout for a request. The [type] is the request type and the result is the timeout in milliseconds.
+     * If [definition] is provided, it will check for custom timeouts first.
+     */
+    operator fun get(type: Timeouts, definition: LanguageServerDefinition?): Int {
+        return definition?.customTimeouts?.get(type) ?: get(type)
+    }
+
+    /**
+     * Get the timeout for a request. The [type] is the request type and the result is the timeout in milliseconds.
+     * Resolves the timeout using the [editor]'s context.
+     */
+    operator fun get(type: Timeouts, editor: LspEditor): Int {
+        return editor.requestManager.getMaximumTimeout(type) ?: get(type)
     }
 
     /**

--- a/editor/src/main/java/io/github/rosemoe/sora/lang/format/FormatterProvider.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/lang/format/FormatterProvider.java
@@ -1,0 +1,51 @@
+/*
+ *    sora-editor - the awesome code editor for Android
+ *    https://github.com/Rosemoe/sora-editor
+ *    Copyright (C) 2020-2024  Rosemoe
+ *
+ *     This library is free software; you can redistribute it and/or
+ *     modify it under the terms of the GNU Lesser General Public
+ *     License as published by the Free Software Foundation; either
+ *     version 2.1 of the License, or (at your option) any later version.
+ *
+ *     This library is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *     Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public
+ *     License along with this library; if not, write to the Free Software
+ *     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *     USA
+ *
+ *     Please contact Rosemoe by email 2073412493@qq.com if you need
+ *     additional information or have any questions
+ */
+package io.github.rosemoe.sora.lang.format;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import io.github.rosemoe.sora.widget.CodeEditor;
+
+/**
+ * Provider for custom formatters.
+ *
+ * @author KonerDev
+ */
+@FunctionalInterface
+public interface FormatterProvider {
+
+    /**
+     * Get a formatter for the specified editor.
+     *
+     * <p>If no custom formatter is available, this method should return
+     * {@code null} to allow the editor to fall back to the language formatter.</p>
+     *
+     * @param editor The current code editor.
+     * @return A custom formatter, or {@code null} to use the default formatter
+     */
+    @Nullable
+    Formatter getFormatter(@NonNull CodeEditor editor);
+
+}

--- a/editor/src/main/java/io/github/rosemoe/sora/lang/styling/ExtraStylesProvider.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/lang/styling/ExtraStylesProvider.java
@@ -1,0 +1,48 @@
+/*
+ *    sora-editor - the awesome code editor for Android
+ *    https://github.com/Rosemoe/sora-editor
+ *    Copyright (C) 2020-2024  Rosemoe
+ *
+ *     This library is free software; you can redistribute it and/or
+ *     modify it under the terms of the GNU Lesser General Public
+ *     License as published by the Free Software Foundation; either
+ *     version 2.1 of the License, or (at your option) any later version.
+ *
+ *     This library is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *     Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public
+ *     License along with this library; if not, write to the Free Software
+ *     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *     USA
+ *
+ *     Please contact Rosemoe by email 2073412493@qq.com if you need
+ *     additional information or have any questions
+ */
+package io.github.rosemoe.sora.lang.styling;
+
+import androidx.annotation.NonNull;
+
+import java.util.List;
+
+import io.github.rosemoe.sora.lang.styling.line.LineAnchorStyle;
+
+/**
+ * Provider for extra styles that are not language specific.
+ *
+ * @author KonerDev
+ */
+@FunctionalInterface
+public interface ExtraStylesProvider {
+
+    /**
+     * Get extra styles for the given line.
+     *
+     * @param line The 0-indexed line number.
+     * @param styles The list to add extra styles to.
+     */
+    void getExtraStyles(int line, @NonNull List<LineAnchorStyle> styles);
+
+}

--- a/editor/src/main/java/io/github/rosemoe/sora/lang/styling/line/LineStyles.kt
+++ b/editor/src/main/java/io/github/rosemoe/sora/lang/styling/line/LineStyles.kt
@@ -35,7 +35,7 @@ class LineStyles(override var line: Int) : LineAnchorStyle(line) {
 
     /**
      * Add a new style object. Note that style object of a given class is allowed to add once.
-     * eg. You can not add two [LineBackground] objects even when they are exactly the same
+     * e.g. You can not add two [LineBackground] objects even when they are exactly the same
      */
     fun addStyle(style: LineAnchorStyle): Int {
         if (style is LineStyles) {

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/CodeEditor.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/CodeEditor.java
@@ -111,7 +111,9 @@ import io.github.rosemoe.sora.lang.Language;
 import io.github.rosemoe.sora.lang.analysis.StyleUpdateRange;
 import io.github.rosemoe.sora.lang.diagnostic.DiagnosticsContainer;
 import io.github.rosemoe.sora.lang.format.Formatter;
+import io.github.rosemoe.sora.lang.format.FormatterProvider;
 import io.github.rosemoe.sora.lang.styling.CodeBlock;
+import io.github.rosemoe.sora.lang.styling.ExtraStylesProvider;
 import io.github.rosemoe.sora.lang.styling.HighlightTextContainer;
 import io.github.rosemoe.sora.lang.styling.Span;
 import io.github.rosemoe.sora.lang.styling.SpanFactory;
@@ -338,6 +340,8 @@ public class CodeEditor extends View implements ContentListener, Formatter.Forma
     private LineNumberTipTextProvider lineNumberTipTextProvider;
     private String formatTip;
     private Language editorLanguage;
+    private FormatterProvider formatterProvider;
+    private ExtraStylesProvider extraStylesProvider;
     private DiagnosticIndicatorStyle diagnosticStyle = DiagnosticIndicatorStyle.WAVY_LINE;
     private long lastMakeVisible = 0;
     private EditorAutoCompletion completionWindow;
@@ -958,7 +962,7 @@ public class CodeEditor extends View implements ContentListener, Formatter.Forma
         // Destroy old one
         var old = editorLanguage;
         if (old != null) {
-            var formatter = old.getFormatter();
+            var formatter = getFormatter();
             formatter.setReceiver(null);
             formatter.destroy();
             old.getAnalyzeManager().setReceiver(null);
@@ -2490,7 +2494,7 @@ public class CodeEditor extends View implements ContentListener, Formatter.Forma
         if (isFormatting()) {
             return false;
         }
-        var formatter = editorLanguage.getFormatter();
+        var formatter = getFormatter();
         formatter.setReceiver(this);
         var formatContent = text.copyText(false);
         formatContent.setUndoEnabled(false);
@@ -2516,13 +2520,25 @@ public class CodeEditor extends View implements ContentListener, Formatter.Forma
         if (isFormatting()) {
             return false;
         }
-        var formatter = editorLanguage.getFormatter();
+        var formatter = getFormatter();
         formatter.setReceiver(this);
         var formatContent = text.copyText(false);
         formatContent.setUndoEnabled(false);
         formatter.formatRegion(formatContent, new TextRange(start, end), getCursorRange());
         postInvalidate();
         return true;
+    }
+
+    @NonNull
+    private Formatter getFormatter() {
+        Formatter formatter = null;
+        if (formatterProvider != null) {
+            formatter = formatterProvider.getFormatter(this);
+        }
+        if (formatter == null) {
+            formatter = editorLanguage.getFormatter();
+        }
+        return formatter;
     }
 
     /**
@@ -3686,6 +3702,24 @@ public class CodeEditor extends View implements ContentListener, Formatter.Forma
         onSelectionChanged(cause);
     }
 
+    public void setFormatterProvider(@Nullable FormatterProvider provider) {
+        this.formatterProvider = provider;
+    }
+
+    @Nullable
+    public FormatterProvider getFormatterProvider() {
+        return formatterProvider;
+    }
+
+    public void setExtraStylesProvider(@Nullable ExtraStylesProvider provider) {
+        this.extraStylesProvider = provider;
+    }
+
+    @Nullable
+    public ExtraStylesProvider getExtraStylesProvider() {
+        return extraStylesProvider;
+    }
+
     /**
      * Get system clipboard manager used by editor
      */
@@ -4111,7 +4145,7 @@ public class CodeEditor extends View implements ContentListener, Formatter.Forma
      * @return whether the editor is currently formatting
      */
     public boolean isFormatting() {
-        return editorLanguage.getFormatter().isRunning();
+        return getFormatter().isRunning();
     }
 
     /**
@@ -4602,7 +4636,7 @@ public class CodeEditor extends View implements ContentListener, Formatter.Forma
         released = true;
         if (editorLanguage != null) {
             editorLanguage.getAnalyzeManager().destroy();
-            var formatter = editorLanguage.getFormatter();
+            var formatter = getFormatter();
             formatter.setReceiver(null);
             formatter.destroy();
             editorLanguage.destroy();

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/EditorRenderer.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/EditorRenderer.java
@@ -1111,7 +1111,11 @@ public class EditorRenderer {
                 if (result == null) {
                     result = new LineStyles(line);
                 } else {
-                    // TODO: Do we need to create a copy of LineStyles object here?
+                    var copy = new LineStyles(line);
+                    for (int i = 0; i < result.getElementCount(); i++) {
+                        copy.addStyle(result.getElementAt(i));
+                    }
+                    result = copy;
                 }
 
                 for (var style : extra) {

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/EditorRenderer.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/EditorRenderer.java
@@ -67,6 +67,7 @@ import io.github.rosemoe.sora.lang.completion.snippet.SnippetItem;
 import io.github.rosemoe.sora.lang.diagnostic.DiagnosticRegion;
 import io.github.rosemoe.sora.lang.styling.CodeBlock;
 import io.github.rosemoe.sora.lang.styling.EmptyReader;
+import io.github.rosemoe.sora.lang.styling.ExtraStylesProvider;
 import io.github.rosemoe.sora.lang.styling.Span;
 import io.github.rosemoe.sora.lang.styling.Spans;
 import io.github.rosemoe.sora.lang.styling.Styles;
@@ -1093,15 +1094,33 @@ public class EditorRenderer {
     protected LineStyles getLineStyles(int line) {
         Styles styles;
         List<LineStyles> lineStylesList;
-        if ((styles = editor.getStyles()) == null || (lineStylesList = styles.lineStyles) == null) {
-            return null;
+        LineStyles result = null;
+        if ((styles = editor.getStyles()) != null && (lineStylesList = styles.lineStyles) != null) {
+            coordinateLine.setLine(line);
+            var index = Collections.binarySearch(lineStylesList, coordinateLine);
+            if (index >= 0 && index < lineStylesList.size()) {
+                result = lineStylesList.get(index);
+            }
         }
-        coordinateLine.setLine(line);
-        var index = Collections.binarySearch(lineStylesList, coordinateLine);
-        if (index >= 0 && index < lineStylesList.size()) {
-            return lineStylesList.get(index);
+
+        ExtraStylesProvider provider = editor.getExtraStylesProvider();
+        if (provider != null) {
+            List<LineAnchorStyle> extra = new ArrayList<>();
+            provider.getExtraStyles(line, extra);
+            if (!extra.isEmpty()) {
+                if (result == null) {
+                    result = new LineStyles(line);
+                } else {
+                    // TODO: Do we need to create a copy of LineStyles object here?
+                }
+
+                for (var style : extra) {
+                    result.addStyle(style);
+                }
+            }
         }
-        return null;
+
+        return result;
     }
 
     @Nullable


### PR DESCRIPTION
This PR closes #851 and #848

I don't know what [dingyi222666](https://github.com/dingyi222666) meant in #821, but for my needs, the current styles provider should be enough.

## Timeouts
- Add `customTimeouts` property to `LanguageServerDefinition` to allow server-specific overrides.
- Implement `getMaximumTimeout` in `AggregatedRequestManager` to resolve the highest timeout among active sessions.
- Update `Timeout` utility with overloaded `get` operators to support resolving timeouts via `LanguageServerDefinition` or `LspEditor` context.
- Update LSP event handlers and `LanguageServerWrapper` to use context-aware timeout resolution instead of global defaults.

## Custom formatters and styles
- Introduce `FormatterProvider` and `ExtraStylesProvider` interfaces to allow customization independent of the language implementation.
- Update `CodeEditor` to support setting and retrieving these providers.
- Modify `EditorRenderer` to incorporate styles from `ExtraStylesProvider` during line rendering.
- Update formatting logic in `CodeEditor` to prioritize `FormatterProvider` over the default language formatter.

@Rosemoe Because you haven't responded to the formatter issue yet, I started working on this. Again, if you have any suggestions, feel free to tell me.
For the `EditorRenderer`, please tell me if it's safe to operate on the `LineStyles` object directly (see TODO).