### PR TITLE
fix(lsp): fix diagnostic publishing

### DIFF
--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/events/diagnostics/PublishDiagnosticsEvent.kt
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/events/diagnostics/PublishDiagnosticsEvent.kt
@@ -44,20 +44,16 @@ class PublishDiagnosticsEvent : EventListener {
         val data = context.getOrNull<List<Diagnostic>>("data") ?: return
 
         val diagnosticsContainer =
-            originEditor.diagnostics ?: DiagnosticsContainer()
+            originEditor.diagnostics ?: DiagnosticsContainer().also { it.attachEditor(originEditor) }
 
-        diagnosticsContainer.reset()
-
-        diagnosticsContainer.addDiagnostics(
-            data.transformToEditorDiagnostics(originEditor)
-        )
+        diagnosticsContainer.setDiagnostics(data.transformToEditorDiagnostics(originEditor))
 
         // run on ui thread
-        originEditor.postOnAnimation {
+        originEditor.post {
             if (data.isEmpty()) {
                 originEditor.diagnostics = null
                 originEditor.getComponent<EditorDiagnosticTooltipWindow>().dismiss()
-                return@postOnAnimation
+                return@post
             }
             originEditor.diagnostics = diagnosticsContainer
         }

--- a/editor/src/main/java/io/github/rosemoe/sora/lang/diagnostic/DiagnosticsContainer.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/lang/diagnostic/DiagnosticsContainer.java
@@ -73,6 +73,16 @@ public class DiagnosticsContainer {
     }
 
     /**
+     * Set multiple diagnostics and clear old ones. Only one event will be dispatched.
+     */
+    public void setDiagnostics(Collection<DiagnosticRegion> regions) {
+        modifyAndDispatch(() -> {
+            this.regions.clear();
+            this.regions.addAll(regions);
+        });
+    }
+
+    /**
      * Add multiple diagnostics
      */
     public void addDiagnostics(Collection<DiagnosticRegion> regions) {


### PR DESCRIPTION
This PR fixes the issue where the `PublishDiagnosticsEvent` was not reliably sent for the initial diagnostics (presumably because editor was not attached).

## Changes
- Add `setDiagnostics` to `DiagnosticsContainer` to allow clearing and adding regions in a single event dispatch.
- Update `PublishDiagnosticsEvent` to use `setDiagnostics` for atomic updates instead of separate reset and add calls.
- Ensure new `DiagnosticsContainer` instances are attached to the editor in `PublishDiagnosticsEvent`.
- Replace `postOnAnimation` with `post` for applying diagnostic updates on the UI thread.