### PR TITLE
feat(editor): migrate to providers API

### DIFF
--- a/app/src/main/java/io/github/rosemoe/sora/app/MainActivity.kt
+++ b/app/src/main/java/io/github/rosemoe/sora/app/MainActivity.kt
@@ -66,10 +66,9 @@ import io.github.rosemoe.sora.lang.JavaLanguageSpec
 import io.github.rosemoe.sora.lang.TsLanguageJava
 import io.github.rosemoe.sora.lang.analysis.AsyncIncrementalAnalyzeManager
 import io.github.rosemoe.sora.lang.diagnostic.DiagnosticRegion
-import io.github.rosemoe.sora.lang.diagnostic.DiagnosticsContainer
 import io.github.rosemoe.sora.lang.styling.color.ConstColor
 import io.github.rosemoe.sora.lang.styling.inlayHint.ColorInlayHint
-import io.github.rosemoe.sora.lang.styling.inlayHint.InlayHintsContainer
+import io.github.rosemoe.sora.lang.styling.inlayHint.InlayHintProvider
 import io.github.rosemoe.sora.lang.styling.inlayHint.TextInlayHint
 import io.github.rosemoe.sora.langs.java.JavaLanguage
 import io.github.rosemoe.sora.langs.monarch.MonarchColorScheme
@@ -160,6 +159,7 @@ class MainActivity : AppCompatActivity() {
     private var searchOptions = SearchOptions(false, false)
     private var undo: MenuItem? = null
     private var redo: MenuItem? = null
+    private var demoInlayHintProvider: InlayHintProvider? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -516,18 +516,18 @@ class MainActivity : AppCompatActivity() {
      */
     private fun setupDiagnostics() {
         val editor = binding.editor
-        val container = DiagnosticsContainer()
-        for (i in 0 until editor.text.lineCount) {
-            val index = editor.text.getCharIndex(i, 0)
-            container.addDiagnostic(
-                DiagnosticRegion(
-                    index,
-                    index + editor.text.getColumnCount(i),
-                    DiagnosticRegion.SEVERITY_ERROR
+        editor.registerDiagnosticProvider { container ->
+            for (i in 0 until editor.text.lineCount) {
+                val index = editor.text.getCharIndex(i, 0)
+                container.addDiagnostic(
+                    DiagnosticRegion(
+                        index,
+                        index + editor.text.getColumnCount(i),
+                        DiagnosticRegion.SEVERITY_ERROR
+                    )
                 )
-            )
+            }
         }
-        editor.diagnostics = container
     }
 
     /**
@@ -586,12 +586,16 @@ class MainActivity : AppCompatActivity() {
                 updatePositionText()
                 updateBtnState()
 
+                demoInlayHintProvider?.let { binding.editor.unregisterInlayHintProvider(it) }
                 if ("big_sample" !in name) {
-                    binding.editor.inlayHints = InlayHintsContainer().also {
-                        it.add(ColorInlayHint(10, 30, ConstColor("#f44336")))
-                        it.add(TextInlayHint(29, 7, "^DigitTens"))
-                        it.add(TextInlayHint(100, 1, "^Numbers"))
+                    demoInlayHintProvider = InlayHintProvider { container ->
+                        container.add(ColorInlayHint(10, 30, ConstColor("#f44336")))
+                        container.add(TextInlayHint(29, 7, "^DigitTens"))
+                        container.add(TextInlayHint(100, 1, "^Numbers"))
                     }
+                    binding.editor.registerInlayHintProvider(demoInlayHintProvider!!)
+                } else {
+                    demoInlayHintProvider = null
                 }
             }
         }

--- a/app/src/main/java/io/github/rosemoe/sora/app/tests/TestActivity.kt
+++ b/app/src/main/java/io/github/rosemoe/sora/app/tests/TestActivity.kt
@@ -31,7 +31,7 @@ import io.github.rosemoe.sora.app.BaseEditorActivity
 import io.github.rosemoe.sora.app.switchThemeIfRequired
 import io.github.rosemoe.sora.lang.diagnostic.DiagnosticDetail
 import io.github.rosemoe.sora.lang.diagnostic.DiagnosticRegion
-import io.github.rosemoe.sora.lang.diagnostic.DiagnosticsContainer
+
 import io.github.rosemoe.sora.lang.diagnostic.Quickfix
 import io.github.rosemoe.sora.langs.java.JavaLanguage
 
@@ -48,7 +48,7 @@ class TestActivity : BaseEditorActivity() {
         val text = generateText()
         editor.setText(text)
 
-        editor.diagnostics = DiagnosticsContainer().also {
+        editor.registerDiagnosticProvider {
             it.addDiagnostic(
                 DiagnosticRegion(
                     37, 50, DiagnosticRegion.SEVERITY_ERROR, 0L, DiagnosticDetail(

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/editor/LspEditor.kt
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/editor/LspEditor.kt
@@ -64,7 +64,7 @@ class LspEditor(
     val uri: FileUri,
 ) {
     private val delegate = LspEditorDelegate(this)
-    private val uiDelegate = LspEditorUIDelegate(this)
+    internal val uiDelegate = LspEditorUIDelegate(this)
 
     private var _currentEditor: WeakReference<CodeEditor?> = WeakReference(null)
 

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/editor/LspEditorUIDelegate.kt
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/editor/LspEditorUIDelegate.kt
@@ -8,8 +8,13 @@ import io.github.rosemoe.sora.event.SelectionChangeEvent
 import io.github.rosemoe.sora.event.SubscriptionReceipt
 import io.github.rosemoe.sora.graphics.inlayHint.ColorInlayHintRenderer
 import io.github.rosemoe.sora.graphics.inlayHint.TextInlayHintRenderer
+import io.github.rosemoe.sora.lang.diagnostic.DiagnosticProvider
+import io.github.rosemoe.sora.lang.diagnostic.DiagnosticRegion
+import io.github.rosemoe.sora.lang.diagnostic.DiagnosticsContainer
 import io.github.rosemoe.sora.lang.styling.HighlightTextContainer
+import io.github.rosemoe.sora.lang.styling.HighlightTextProvider
 import io.github.rosemoe.sora.lang.styling.color.EditorColor
+import io.github.rosemoe.sora.lang.styling.inlayHint.InlayHintProvider
 import io.github.rosemoe.sora.lang.styling.inlayHint.InlayHintsContainer
 import io.github.rosemoe.sora.lsp.editor.codeaction.CodeActionWindow
 import io.github.rosemoe.sora.lsp.editor.diagnostics.LspDiagnosticTooltipLayout
@@ -40,7 +45,7 @@ import org.eclipse.lsp4j.SignatureHelp
 import org.eclipse.lsp4j.jsonrpc.messages.Either
 import java.lang.ref.WeakReference
 
-internal class LspEditorUIDelegate(private val editor: LspEditor) {
+internal class LspEditorUIDelegate(private val editor: LspEditor) : InlayHintProvider, DiagnosticProvider, HighlightTextProvider {
 
     private var currentEditorRef: WeakReference<CodeEditor?> = WeakReference(null as CodeEditor?)
     private var hoverWindowRef: WeakReference<HoverWindow?> = WeakReference(null as HoverWindow?)
@@ -49,6 +54,8 @@ internal class LspEditorUIDelegate(private val editor: LspEditor) {
     private var codeActionWindowRef: WeakReference<CodeActionWindow?> = WeakReference(null as CodeActionWindow?)
 
     private var cachedInlayHints: List<InlayHint>? = null
+    private var cachedHighlights: List<HighlightTextContainer.HighlightText>? = null
+    private var cachedDiagnostics: List<DiagnosticRegion>? = null
     internal var cachedDocumentColors: List<ColorInformation>? = null
         private set
 
@@ -98,11 +105,17 @@ internal class LspEditorUIDelegate(private val editor: LspEditor) {
                         TextInlayHintRenderer.DefaultInstance,
                         ColorInlayHintRenderer.DefaultInstance
                     )
+                    it.registerInlayHintProvider(this@LspEditorUIDelegate)
+                    it.registerDiagnosticProvider(this@LspEditorUIDelegate)
+                    it.registerHighlightTextProvider(this@LspEditorUIDelegate)
                     editor.coroutineScope.launch {
                         editor.requestInlayHint(CharPosition(0, 0))
                         editor.requestDocumentColor()
                     }
                 } else {
+                    it.unregisterInlayHintProvider(this@LspEditorUIDelegate)
+                    it.unregisterDiagnosticProvider(this@LspEditorUIDelegate)
+                    it.unregisterHighlightTextProvider(this@LspEditorUIDelegate)
                     resetInlinePresentations()
                 }
             }
@@ -149,6 +162,9 @@ internal class LspEditorUIDelegate(private val editor: LspEditor) {
                 TextInlayHintRenderer.DefaultInstance,
                 ColorInlayHintRenderer.DefaultInstance
             )
+            codeEditor.registerInlayHintProvider(this)
+            codeEditor.registerDiagnosticProvider(this)
+            codeEditor.registerHighlightTextProvider(this)
             editor.coroutineScope.launch {
                 editor.requestInlayHint(CharPosition(0, 0))
                 editor.requestDocumentColor()
@@ -187,6 +203,12 @@ internal class LspEditorUIDelegate(private val editor: LspEditor) {
 
     fun detachEditor() {
         clearSubscriptions()
+
+        currentEditorRef.get()?.let {
+            it.unregisterInlayHintProvider(this)
+            it.unregisterDiagnosticProvider(this)
+            it.unregisterHighlightTextProvider(this)
+        }
 
         hoverWindow?.setEnabled(false)
         hoverWindowRef.clear()
@@ -254,11 +276,10 @@ internal class LspEditorUIDelegate(private val editor: LspEditor) {
         val editorInstance = currentEditorRef.get() ?: return
 
         if (highlights.isNullOrEmpty()) {
-            editorInstance.post { editorInstance.highlightTexts = null }
+            cachedHighlights = null
+            editorInstance.post { editorInstance.invalidateHighlightTexts() }
             return
         }
-
-        val container = HighlightTextContainer()
 
         val colors = mapOf(
             DocumentHighlightKind.Write to EditorColor(EditorColorScheme.TEXT_HIGHLIGHT_STRONG_BACKGROUND),
@@ -272,8 +293,9 @@ internal class LspEditorUIDelegate(private val editor: LspEditor) {
             DocumentHighlightKind.Text to EditorColor(EditorColorScheme.TEXT_HIGHLIGHT_BORDER)
         )
 
+        val newHighlights = mutableListOf<HighlightTextContainer.HighlightText>()
         highlights.forEach {
-            container.add(
+            newHighlights.add(
                 HighlightTextContainer.HighlightText(
                     it.range.start.line,
                     it.range.start.character,
@@ -284,8 +306,9 @@ internal class LspEditorUIDelegate(private val editor: LspEditor) {
                 )
             )
         }
+        cachedHighlights = newHighlights
 
-        editorInstance.post { editorInstance.highlightTexts = container }
+        editorInstance.post { editorInstance.invalidateHighlightTexts() }
     }
 
     fun showInlayHints(inlayHints: List<InlayHint>?) {
@@ -308,31 +331,41 @@ internal class LspEditorUIDelegate(private val editor: LspEditor) {
 
     private fun updateInlinePresentations() {
         val editorInstance = currentEditorRef.get() ?: return
-
-        val hasInlayHints = !cachedInlayHints.isNullOrEmpty()
-        val hasDocumentColors = !cachedDocumentColors.isNullOrEmpty()
-
-        if (!hasInlayHints && !hasDocumentColors) {
-            editorInstance.post { editorInstance.inlayHints = null }
-            return
+        editorInstance.post {
+            editorInstance.invalidateInlayHints()
         }
+    }
 
-        val container = InlayHintsContainer()
+    override fun provideInlayHints(container: InlayHintsContainer) {
         cachedInlayHints?.inlayHintToDisplay()?.forEach(container::add)
         cachedDocumentColors?.colorInfoToDisplay()?.forEach(container::add)
+    }
 
-        editorInstance.post { editorInstance.inlayHints = container }
+    fun setDiagnostics(diagnostics: List<DiagnosticRegion>?) {
+        cachedDiagnostics = diagnostics
+        currentEditorRef.get()?.let {
+            it.post { it.invalidateDiagnostics() }
+        }
+    }
+
+    override fun provideDiagnostics(container: DiagnosticsContainer) {
+        cachedDiagnostics?.let { container.addDiagnostics(it) }
+    }
+
+    override fun provideHighlightTexts(container: HighlightTextContainer) {
+        cachedHighlights?.let { container.addAll(it) }
     }
 
     private fun resetInlinePresentations() {
         cachedInlayHints = null
         cachedDocumentColors = null
+        cachedHighlights = null
+        cachedDiagnostics = null
         currentEditorRef.get()?.let {
-            if (it.inlayHints != null) {
-                it.post { it.inlayHints = null }
-            }
-            if (it.highlightTexts != null) {
-                it.post { it.highlightTexts = null }
+            it.post {
+                it.invalidateInlayHints()
+                it.invalidateDiagnostics()
+                it.invalidateHighlightTexts()
             }
         }
     }

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/events/diagnostics/PublishDiagnosticsEvent.kt
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/events/diagnostics/PublishDiagnosticsEvent.kt
@@ -43,19 +43,17 @@ class PublishDiagnosticsEvent : EventListener {
         val originEditor = lspEditor.editor ?: return
         val data = context.getOrNull<List<Diagnostic>>("data") ?: return
 
-        val diagnosticsContainer =
-            originEditor.diagnostics ?: DiagnosticsContainer().also { it.attachEditor(originEditor) }
-
-        diagnosticsContainer.setDiagnostics(data.transformToEditorDiagnostics(originEditor))
+        // transform lsp diagnostics to editor diagnostics
+        val diagnostics = data.transformToEditorDiagnostics(originEditor)
 
         // run on ui thread
         originEditor.post {
             if (data.isEmpty()) {
-                originEditor.diagnostics = null
+                lspEditor.uiDelegate.setDiagnostics(null)
                 originEditor.getComponent<EditorDiagnosticTooltipWindow>().dismiss()
                 return@post
             }
-            originEditor.diagnostics = diagnosticsContainer
+            lspEditor.uiDelegate.setDiagnostics(diagnostics)
         }
     }
 }

--- a/editor/src/main/java/io/github/rosemoe/sora/lang/diagnostic/DiagnosticProvider.kt
+++ b/editor/src/main/java/io/github/rosemoe/sora/lang/diagnostic/DiagnosticProvider.kt
@@ -1,0 +1,11 @@
+package io.github.rosemoe.sora.lang.diagnostic
+
+/**
+ * Provider for diagnostics
+ */
+fun interface DiagnosticProvider {
+    /**
+     * Provide diagnostics to the given container
+     */
+    fun provideDiagnostics(container: DiagnosticsContainer)
+}

--- a/editor/src/main/java/io/github/rosemoe/sora/lang/diagnostic/DiagnosticsContainer.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/lang/diagnostic/DiagnosticsContainer.java
@@ -183,4 +183,9 @@ public class DiagnosticsContainer {
         modifyAndDispatch(regions::clear);
     }
 
+    @NonNull
+    public synchronized List<DiagnosticRegion> getRegions() {
+        return new ArrayList<>(regions);
+    }
+
 }

--- a/editor/src/main/java/io/github/rosemoe/sora/lang/styling/HighlightTextProvider.kt
+++ b/editor/src/main/java/io/github/rosemoe/sora/lang/styling/HighlightTextProvider.kt
@@ -1,0 +1,11 @@
+package io.github.rosemoe.sora.lang.styling
+
+/**
+ * Provider for text highlights
+ */
+fun interface HighlightTextProvider {
+    /**
+     * Provide text highlights to the given container
+     */
+    fun provideHighlightTexts(container: HighlightTextContainer)
+}

--- a/editor/src/main/java/io/github/rosemoe/sora/lang/styling/inlayHint/InlayHintProvider.kt
+++ b/editor/src/main/java/io/github/rosemoe/sora/lang/styling/inlayHint/InlayHintProvider.kt
@@ -1,0 +1,13 @@
+package io.github.rosemoe.sora.lang.styling.inlayHint
+
+import androidx.annotation.NonNull
+
+/**
+ * Provider for inlay hints
+ */
+fun interface InlayHintProvider {
+    /**
+     * Provide inlay hints to the given container
+     */
+    fun provideInlayHints(container: InlayHintsContainer)
+}

--- a/editor/src/main/java/io/github/rosemoe/sora/lang/styling/inlayHint/inlayHints.kt
+++ b/editor/src/main/java/io/github/rosemoe/sora/lang/styling/inlayHint/inlayHints.kt
@@ -33,7 +33,7 @@ import io.github.rosemoe.sora.text.TextRange
  * @see io.github.rosemoe.sora.graphics.inlayHint.TextInlayHintRenderer
  * @author Rosemoe
  */
-class TextInlayHint(
+open class TextInlayHint(
     line: Int,
     column: Int,
     val text: String
@@ -45,7 +45,7 @@ class TextInlayHint(
 
 }
 
-class ColorInlayHint(
+open class ColorInlayHint(
     line: Int,
     column: Int,
     val color: ResolvableColor,

--- a/editor/src/main/java/io/github/rosemoe/sora/lang/styling/util/PointAnchorContainer.kt
+++ b/editor/src/main/java/io/github/rosemoe/sora/lang/styling/util/PointAnchorContainer.kt
@@ -155,6 +155,22 @@ open class PointAnchoredContainer<T : PointAnchoredObject> {
         }
     }
 
+    fun isEmpty(): Boolean {
+        return objects.isEmpty()
+    }
+
+    fun clear() {
+        objects.clear()
+    }
+
+    fun addAll(other: PointAnchoredContainer<T>) {
+        other.forEach { add(it) }
+    }
+
+    fun forEach(action: (T) -> Unit) {
+        objects.forEach(action)
+    }
+
     private class Anchor(
         override var line: Int,
         override var column: Int

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/CodeEditor.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/CodeEditor.java
@@ -109,15 +109,18 @@ import io.github.rosemoe.sora.graphics.inlayHint.InlayHintRendererProvider;
 import io.github.rosemoe.sora.lang.EmptyLanguage;
 import io.github.rosemoe.sora.lang.Language;
 import io.github.rosemoe.sora.lang.analysis.StyleUpdateRange;
+import io.github.rosemoe.sora.lang.diagnostic.DiagnosticProvider;
 import io.github.rosemoe.sora.lang.diagnostic.DiagnosticsContainer;
 import io.github.rosemoe.sora.lang.format.Formatter;
 import io.github.rosemoe.sora.lang.format.FormatterProvider;
 import io.github.rosemoe.sora.lang.styling.CodeBlock;
 import io.github.rosemoe.sora.lang.styling.ExtraStylesProvider;
 import io.github.rosemoe.sora.lang.styling.HighlightTextContainer;
+import io.github.rosemoe.sora.lang.styling.HighlightTextProvider;
 import io.github.rosemoe.sora.lang.styling.Span;
 import io.github.rosemoe.sora.lang.styling.SpanFactory;
 import io.github.rosemoe.sora.lang.styling.Styles;
+import io.github.rosemoe.sora.lang.styling.inlayHint.InlayHintProvider;
 import io.github.rosemoe.sora.lang.styling.inlayHint.InlayHintsContainer;
 import io.github.rosemoe.sora.lang.styling.inlayHint.IntSetUpdateRange;
 import io.github.rosemoe.sora.text.CharPosition;
@@ -268,6 +271,10 @@ public class CodeEditor extends View implements ContentListener, Formatter.Forma
     protected EditorContextMenuCreator contextMenuCreator;
     protected List<Span> defaultSpans = new ArrayList<>(2);
     protected EditorStyleDelegate styleDelegate;
+    private final List<ExtraStylesProvider> extraStylesProviders = new ArrayList<>();
+    private final List<InlayHintProvider> inlayHintProviders = new ArrayList<>();
+    private final List<DiagnosticProvider> diagnosticProviders = new ArrayList<>();
+    private final List<HighlightTextProvider> highlightTextProviders = new ArrayList<>();
     int startedActionMode;
     protected CharPosition selectionAnchor;
     EditorInputConnection inputConnection;
@@ -341,7 +348,6 @@ public class CodeEditor extends View implements ContentListener, Formatter.Forma
     private String formatTip;
     private Language editorLanguage;
     private FormatterProvider formatterProvider;
-    private ExtraStylesProvider extraStylesProvider;
     private DiagnosticIndicatorStyle diagnosticStyle = DiagnosticIndicatorStyle.WAVY_LINE;
     private long lastMakeVisible = 0;
     private EditorAutoCompletion completionWindow;
@@ -665,6 +671,10 @@ public class CodeEditor extends View implements ContentListener, Formatter.Forma
         // Config scale detector
         scaleDetector.setQuickScaleEnabled(false);
         snippetController = new SnippetController(this);
+
+        registerInlayHintProvider(styleDelegate);
+        registerDiagnosticProvider(styleDelegate);
+        registerHighlightTextProvider(styleDelegate);
     }
 
     /**
@@ -1006,10 +1016,10 @@ public class CodeEditor extends View implements ContentListener, Formatter.Forma
 
         // reset inlay hints (partially re-layout required)
         if (this.inlayHints != null) {
-            setInlayHints(null);
+            internalSetInlayHints(null);
         }
         if (this.highlightTextContainer != null) {
-            setHighlightTexts(null);
+            internalSetHighlightTexts(null);
         }
     }
 
@@ -3711,13 +3721,22 @@ public class CodeEditor extends View implements ContentListener, Formatter.Forma
         return formatterProvider;
     }
 
-    public void setExtraStylesProvider(@Nullable ExtraStylesProvider provider) {
-        this.extraStylesProvider = provider;
+    public void registerExtraStylesProvider(@NonNull ExtraStylesProvider provider) {
+        if (!extraStylesProviders.contains(provider)) {
+            extraStylesProviders.add(provider);
+            invalidate();
+        }
     }
 
-    @Nullable
-    public ExtraStylesProvider getExtraStylesProvider() {
-        return extraStylesProvider;
+    public void unregisterExtraStylesProvider(@NonNull ExtraStylesProvider provider) {
+        if (extraStylesProviders.remove(provider)) {
+            invalidate();
+        }
+    }
+
+    @NonNull
+    public List<ExtraStylesProvider> getExtraStylesProviders() {
+        return extraStylesProviders;
     }
 
     /**
@@ -4315,8 +4334,35 @@ public class CodeEditor extends View implements ContentListener, Formatter.Forma
         return diagnostics;
     }
 
-    @UiThread
-    public void setDiagnostics(@Nullable DiagnosticsContainer diagnostics) {
+
+    public void registerDiagnosticProvider(@NonNull DiagnosticProvider provider) {
+        synchronized (diagnosticProviders) {
+            if (!diagnosticProviders.contains(provider)) {
+                diagnosticProviders.add(provider);
+                invalidateDiagnostics();
+            }
+        }
+    }
+
+    public void unregisterDiagnosticProvider(@NonNull DiagnosticProvider provider) {
+        synchronized (diagnosticProviders) {
+            if (diagnosticProviders.remove(provider)) {
+                invalidateDiagnostics();
+            }
+        }
+    }
+
+    public void invalidateDiagnostics() {
+        synchronized (diagnosticProviders) {
+            var merged = new DiagnosticsContainer(false);
+            for (var provider : diagnosticProviders) {
+                provider.provideDiagnostics(merged);
+            }
+            internalSetDiagnostics(merged.getRegions().isEmpty() ? null : merged);
+        }
+    }
+
+    private void internalSetDiagnostics(@Nullable DiagnosticsContainer diagnostics) {
         if (this.diagnostics != null) {
             this.diagnostics.detachEditor();
         }
@@ -4329,7 +4375,39 @@ public class CodeEditor extends View implements ContentListener, Formatter.Forma
         invalidate();
     }
 
-    public void setInlayHints(@Nullable InlayHintsContainer inlayHints) {
+    @Nullable
+    public InlayHintsContainer getInlayHints() {
+        return inlayHints;
+    }
+
+    public void registerInlayHintProvider(@NonNull InlayHintProvider provider) {
+        synchronized (inlayHintProviders) {
+            if (!inlayHintProviders.contains(provider)) {
+                inlayHintProviders.add(provider);
+                invalidateInlayHints();
+            }
+        }
+    }
+
+    public void unregisterInlayHintProvider(@NonNull InlayHintProvider provider) {
+        synchronized (inlayHintProviders) {
+            if (inlayHintProviders.remove(provider)) {
+                invalidateInlayHints();
+            }
+        }
+    }
+
+    public void invalidateInlayHints() {
+        synchronized (inlayHintProviders) {
+            var merged = new InlayHintsContainer();
+            for (var provider : inlayHintProviders) {
+                provider.provideInlayHints(merged);
+            }
+            internalSetInlayHints(merged.isEmpty() ? null : merged);
+        }
+    }
+
+    private void internalSetInlayHints(@Nullable InlayHintsContainer inlayHints) {
         var affectedLines = new MutableIntSet();
         var oldInlayHints = this.inlayHints;
         if (oldInlayHints != null) {
@@ -4349,12 +4427,38 @@ public class CodeEditor extends View implements ContentListener, Formatter.Forma
     }
 
     @Nullable
-    public InlayHintsContainer getInlayHints() {
-        return inlayHints;
+    public HighlightTextContainer getHighlightTexts() {
+        return highlightTextContainer;
     }
 
-    @UiThread
-    public void setHighlightTexts(@Nullable HighlightTextContainer highlightTexts) {
+    public void registerHighlightTextProvider(@NonNull HighlightTextProvider provider) {
+        synchronized (highlightTextProviders) {
+            if (!highlightTextProviders.contains(provider)) {
+                highlightTextProviders.add(provider);
+                invalidateHighlightTexts();
+            }
+        }
+    }
+
+    public void unregisterHighlightTextProvider(@NonNull HighlightTextProvider provider) {
+        synchronized (highlightTextProviders) {
+            if (highlightTextProviders.remove(provider)) {
+                invalidateHighlightTexts();
+            }
+        }
+    }
+
+    public void invalidateHighlightTexts() {
+        synchronized (highlightTextProviders) {
+            var merged = new HighlightTextContainer();
+            for (var provider : highlightTextProviders) {
+                provider.provideHighlightTexts(merged);
+            }
+            internalSetHighlightTexts(merged.isEmpty() ? null : merged);
+        }
+    }
+
+    private void internalSetHighlightTexts(@Nullable HighlightTextContainer highlightTexts) {
         var affectedLines = new MutableIntSet();
         var oldHighlights = this.highlightTextContainer;
         if (oldHighlights != null) {
@@ -4370,13 +4474,6 @@ public class CodeEditor extends View implements ContentListener, Formatter.Forma
                 affectedLines.add(line);
             }
         }
-        if (affectedLines._size == 0) {
-            return;
-        }
-        if (layout == null || renderContext == null) {
-            invalidate();
-            return;
-        }
         var range = new IntSetUpdateRange(affectedLines);
         if (!layoutBusy) {
             layout.invalidateLines(range);
@@ -4384,13 +4481,8 @@ public class CodeEditor extends View implements ContentListener, Formatter.Forma
             createLayout();
         }
         renderContext.invalidateRenderNodes();
-        invalidate();
     }
 
-    @Nullable
-    public HighlightTextContainer getHighlightTexts() {
-        return highlightTextContainer;
-    }
 
     /**
      * Hide auto complete window if shown

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/EditorRenderer.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/EditorRenderer.java
@@ -67,7 +67,6 @@ import io.github.rosemoe.sora.lang.completion.snippet.SnippetItem;
 import io.github.rosemoe.sora.lang.diagnostic.DiagnosticRegion;
 import io.github.rosemoe.sora.lang.styling.CodeBlock;
 import io.github.rosemoe.sora.lang.styling.EmptyReader;
-import io.github.rosemoe.sora.lang.styling.ExtraStylesProvider;
 import io.github.rosemoe.sora.lang.styling.Span;
 import io.github.rosemoe.sora.lang.styling.Spans;
 import io.github.rosemoe.sora.lang.styling.Styles;
@@ -445,10 +444,26 @@ public class EditorRenderer {
         if ((styles = editor.getStyles()) != null) {
             if (styles.styleTypeCount != null) {
                 var count = styles.styleTypeCount.get(LineSideIcon.class);
-                if (count == null) {
-                    return false;
+                if (count != null && count.value > 0) {
+                    return true;
                 }
-                return count.value > 0;
+            }
+        }
+        var providers = editor.getExtraStylesProviders();
+        if (!providers.isEmpty()) {
+            var first = editor.getFirstVisibleLine();
+            var last = editor.getLastVisibleLine();
+            var extra = new ArrayList<LineAnchorStyle>();
+            for (int i = first; i <= last; i++) {
+                extra.clear();
+                for (int j = 0; j < providers.size(); j++) {
+                    providers.get(j).getExtraStyles(i, extra);
+                }
+                for (var s : extra) {
+                    if (s instanceof LineSideIcon) {
+                        return true;
+                    }
+                }
             }
         }
         return false;
@@ -1103,10 +1118,12 @@ public class EditorRenderer {
             }
         }
 
-        ExtraStylesProvider provider = editor.getExtraStylesProvider();
-        if (provider != null) {
+        var providers = editor.getExtraStylesProviders();
+        if (!providers.isEmpty()) {
             List<LineAnchorStyle> extra = new ArrayList<>();
-            provider.getExtraStyles(line, extra);
+            for (int j = 0; j < providers.size(); j++) {
+                providers.get(j).getExtraStyles(line, extra);
+            }
             if (!extra.isEmpty()) {
                 if (result == null) {
                     result = new LineStyles(line);

--- a/editor/src/main/java/io/github/rosemoe/sora/widget/EditorStyleDelegate.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/EditorStyleDelegate.java
@@ -36,15 +36,22 @@ import io.github.rosemoe.sora.lang.analysis.StyleReceiver;
 import io.github.rosemoe.sora.lang.analysis.StyleUpdateRange;
 import io.github.rosemoe.sora.lang.brackets.BracketsProvider;
 import io.github.rosemoe.sora.lang.brackets.PairedBracket;
+import io.github.rosemoe.sora.lang.diagnostic.DiagnosticProvider;
 import io.github.rosemoe.sora.lang.diagnostic.DiagnosticsContainer;
+import io.github.rosemoe.sora.lang.styling.HighlightTextProvider;
+import io.github.rosemoe.sora.lang.styling.HighlightTextContainer;
 import io.github.rosemoe.sora.lang.styling.Styles;
+import io.github.rosemoe.sora.lang.styling.inlayHint.InlayHintProvider;
 import io.github.rosemoe.sora.lang.styling.inlayHint.InlayHintsContainer;
 
-public class EditorStyleDelegate implements StyleReceiver {
+public class EditorStyleDelegate implements StyleReceiver, InlayHintProvider, DiagnosticProvider, HighlightTextProvider {
 
     private final WeakReference<CodeEditor> editorRef;
     private PairedBracket foundPair;
     private BracketsProvider bracketsProvider;
+    private DiagnosticsContainer diagnostics;
+    private InlayHintsContainer inlayHints;
+    private HighlightTextContainer highlightTexts;
 
     EditorStyleDelegate(@NonNull CodeEditor editor) {
         editorRef = new WeakReference<>(editor);
@@ -80,6 +87,9 @@ public class EditorStyleDelegate implements StyleReceiver {
     void reset() {
         foundPair = null;
         bracketsProvider = null;
+        diagnostics = null;
+        inlayHints = null;
+        highlightTexts = null;
     }
 
     private void runOnUiThread(Runnable operation) {
@@ -116,7 +126,8 @@ public class EditorStyleDelegate implements StyleReceiver {
     public void setDiagnostics(@NonNull AnalyzeManager sourceManager, @Nullable DiagnosticsContainer diagnostics) {
         var editor = editorRef.get();
         if (editor != null && sourceManager == editor.getEditorLanguage().getAnalyzeManager()) {
-            runOnUiThread(() -> editor.setDiagnostics(diagnostics));
+            this.diagnostics = diagnostics;
+            runOnUiThread(editor::invalidateDiagnostics);
         }
     }
 
@@ -124,7 +135,37 @@ public class EditorStyleDelegate implements StyleReceiver {
     public void setInlayHints(@NonNull AnalyzeManager sourceManager, @Nullable InlayHintsContainer inlayHints) {
         var editor = editorRef.get();
         if (editor != null && sourceManager == editor.getEditorLanguage().getAnalyzeManager()) {
-            runOnUiThread(() -> editor.setInlayHints(inlayHints));
+            this.inlayHints = inlayHints;
+            runOnUiThread(editor::invalidateInlayHints);
+        }
+    }
+
+    public void setHighlightTexts(@NonNull AnalyzeManager sourceManager, @Nullable HighlightTextContainer highlightTexts) {
+        var editor = editorRef.get();
+        if (editor != null && sourceManager == editor.getEditorLanguage().getAnalyzeManager()) {
+            this.highlightTexts = highlightTexts;
+            runOnUiThread(editor::invalidateHighlightTexts);
+        }
+    }
+
+    @Override
+    public void provideInlayHints(@NonNull InlayHintsContainer container) {
+        if (inlayHints != null) {
+            container.addAll(inlayHints);
+        }
+    }
+
+    @Override
+    public void provideDiagnostics(@NonNull DiagnosticsContainer container) {
+        if (diagnostics != null) {
+            container.addDiagnostics(diagnostics.getRegions());
+        }
+    }
+
+    @Override
+    public void provideHighlightTexts(@NonNull HighlightTextContainer container) {
+        if (highlightTexts != null) {
+            container.addAll(highlightTexts.asList());
         }
     }
 


### PR DESCRIPTION
This PR migrates the diagnostics, inlay hints, and document highlights to a provider-based API. Instead of using a single setter accessed concurrently by different parts of the program, which leads to conflicts (such as when `editor-lsp` clears inlay hints, thereby removing the client's own inlay hints as well, providers can now be registered/unregistered. Each contributes independently to the inlay hints/diagnostics/..., thereby resolving these conflicts.

Virtually every editor uses this architecture instead of allowing direct access to the underlying object (VS Code, IntelliJ, ...).

## Changes
- Introduce `DiagnosticProvider`, `InlayHintProvider`, and `HighlightTextProvider` functional interfaces.
- Update `CodeEditor` to allow registering and unregistering multiple providers for diagnostics, inlay hints, highlight texts, and extra styles.
- Implement invalidation and merging logic in `CodeEditor` to aggregate data from all active providers into their respective containers.
- Refactor `EditorStyleDelegate` to implement the new provider interfaces and manage data locally before invalidating the editor state.
- Update `EditorRenderer` to iterate through all registered `ExtraStylesProvider` instances during rendering.
- Modify `LspEditorUIDelegate` to act as a provider, improving the integration of LSP-driven diagnostics and hints.
- Add utility methods to `PointAnchoredContainer` and `DiagnosticsContainer` to facilitate data merging.