### PR TITLE
feat(lsp): more LSP events + custom requests/notifications

### DIFF
--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/client/DefaultLanguageClient.kt
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/client/DefaultLanguageClient.kt
@@ -34,20 +34,24 @@ import io.github.rosemoe.sora.lsp.utils.toFileUri
 import org.eclipse.lsp4j.ApplyWorkspaceEditParams
 import org.eclipse.lsp4j.ApplyWorkspaceEditResponse
 import org.eclipse.lsp4j.ConfigurationParams
+import org.eclipse.lsp4j.LogTraceParams
 import org.eclipse.lsp4j.MessageActionItem
 import org.eclipse.lsp4j.MessageParams
+import org.eclipse.lsp4j.ProgressParams
 import org.eclipse.lsp4j.PublishDiagnosticsParams
 import org.eclipse.lsp4j.RegistrationParams
 import org.eclipse.lsp4j.ShowMessageRequestParams
 import org.eclipse.lsp4j.UnregistrationParams
+import org.eclipse.lsp4j.WorkDoneProgressCreateParams
 import org.eclipse.lsp4j.WorkspaceFolder
+import org.eclipse.lsp4j.jsonrpc.Endpoint
 import org.eclipse.lsp4j.services.LanguageClient
 import java.net.URI
 import java.util.concurrent.CompletableFuture
 
 
 open class DefaultLanguageClient(protected val context: ClientContext) :
-    LanguageClient {
+    LanguageClient, Endpoint {
 
     override fun applyEdit(params: ApplyWorkspaceEditParams): CompletableFuture<ApplyWorkspaceEditResponse> {
         val project = context.project ?: return CompletableFuture.completedFuture(null)
@@ -132,6 +136,29 @@ open class DefaultLanguageClient(protected val context: ClientContext) :
 
     override fun logMessage(messageParams: MessageParams) {
         context.eventListener.onLogMessage(messageParams)
+    }
+
+    override fun createProgress(params: WorkDoneProgressCreateParams): CompletableFuture<Void> {
+        context.eventListener.onWorkDoneProgressCreate(params)
+        return CompletableFuture.completedFuture(null)
+    }
+
+    override fun notifyProgress(params: ProgressParams) {
+        context.eventListener.onProgress(params)
+    }
+
+    override fun logTrace(params: LogTraceParams) {
+        context.eventListener.onLogTrace(params)
+    }
+
+    override fun notify(method: String, parameter: Any?) {
+        context.eventListener.notify(method, parameter)
+    }
+
+    override fun request(method: String, parameter: Any?): CompletableFuture<*> {
+        return context.eventListener.request(method, parameter) ?: CompletableFuture<Any>().apply {
+            completeExceptionally(UnsupportedOperationException("Unsupported request: $method"))
+        }
     }
 
     companion object {

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/client/languageserver/requestmanager/AggregatedRequestManager.kt
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/client/languageserver/requestmanager/AggregatedRequestManager.kt
@@ -52,17 +52,20 @@ import org.eclipse.lsp4j.InlayHint
 import org.eclipse.lsp4j.InlayHintParams
 import org.eclipse.lsp4j.Location
 import org.eclipse.lsp4j.LocationLink
+import org.eclipse.lsp4j.LogTraceParams
 import org.eclipse.lsp4j.MessageActionItem
 import org.eclipse.lsp4j.MessageParams
 import org.eclipse.lsp4j.PrepareRenameDefaultBehavior
 import org.eclipse.lsp4j.PrepareRenameParams
 import org.eclipse.lsp4j.PrepareRenameResult
+import org.eclipse.lsp4j.ProgressParams
 import org.eclipse.lsp4j.PublishDiagnosticsParams
 import org.eclipse.lsp4j.Range
 import org.eclipse.lsp4j.ReferenceParams
 import org.eclipse.lsp4j.RegistrationParams
 import org.eclipse.lsp4j.RenameParams
 import org.eclipse.lsp4j.ServerCapabilities
+import org.eclipse.lsp4j.SetTraceParams
 import org.eclipse.lsp4j.ShowMessageRequestParams
 import org.eclipse.lsp4j.SignatureHelp
 import org.eclipse.lsp4j.SignatureHelpParams
@@ -72,9 +75,12 @@ import org.eclipse.lsp4j.TextEdit
 import org.eclipse.lsp4j.TypeDefinitionParams
 import org.eclipse.lsp4j.UnregistrationParams
 import org.eclipse.lsp4j.WillSaveTextDocumentParams
+import org.eclipse.lsp4j.WorkDoneProgressCancelParams
+import org.eclipse.lsp4j.WorkDoneProgressCreateParams
 import org.eclipse.lsp4j.WorkspaceEdit
 import org.eclipse.lsp4j.WorkspaceSymbol
 import org.eclipse.lsp4j.WorkspaceSymbolParams
+import org.eclipse.lsp4j.jsonrpc.Endpoint
 import org.eclipse.lsp4j.jsonrpc.messages.Either
 import org.eclipse.lsp4j.jsonrpc.messages.Either3
 import org.eclipse.lsp4j.services.TextDocumentService
@@ -114,7 +120,9 @@ class AggregatedRequestManager(
 
     /** Combine capabilities from every active session, preferring the first non-null value per field. */
     private fun mergeCapabilities(): ServerCapabilities? {
-        val all = sessionEntries.mapNotNull { it.getServerCapabilities() }
+        val all = sessionEntries.mapNotNull {
+            it.getCachedServerCapabilities()
+        }
         if (all.isEmpty()) {
             return null
         }
@@ -275,6 +283,36 @@ class AggregatedRequestManager(
 
     override fun publishDiagnostics(publishDiagnosticsParams: PublishDiagnosticsParams) {
         fanOut { publishDiagnostics(publishDiagnosticsParams) }
+    }
+
+    override fun logTrace(params: LogTraceParams) {
+        fanOut { logTrace(params) }
+    }
+
+    override fun setTrace(params: SetTraceParams) {
+        fanOut { setTrace(params) }
+    }
+
+    override fun notifyProgress(params: ProgressParams) {
+        fanOut { notifyProgress(params) }
+    }
+
+    override fun createProgress(params: WorkDoneProgressCreateParams): CompletableFuture<Void> {
+        return firstFuture { createProgress(params) } ?: CompletableFuture.completedFuture(null)
+    }
+
+    override fun cancelProgress(params: WorkDoneProgressCancelParams) {
+        fanOut { cancelProgress(params) }
+    }
+
+    override fun notify(method: String, parameter: Any?) {
+        fanOut { (this as? Endpoint)?.notify(method, parameter) }
+    }
+
+    override fun request(method: String, parameter: Any?): CompletableFuture<*> {
+        return firstFuture { (this as? Endpoint)?.request(method, parameter) } ?: CompletableFuture<Any>().apply {
+            completeExceptionally(UnsupportedOperationException("Unsupported request: $method"))
+        }
     }
 
     override fun initialize(params: InitializeParams): CompletableFuture<InitializeResult>? {

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/client/languageserver/requestmanager/DefaultRequestManager.kt
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/client/languageserver/requestmanager/DefaultRequestManager.kt
@@ -73,17 +73,20 @@ import org.eclipse.lsp4j.InlayHint
 import org.eclipse.lsp4j.InlayHintParams
 import org.eclipse.lsp4j.Location
 import org.eclipse.lsp4j.LocationLink
+import org.eclipse.lsp4j.LogTraceParams
 import org.eclipse.lsp4j.MessageActionItem
 import org.eclipse.lsp4j.MessageParams
 import org.eclipse.lsp4j.PrepareRenameDefaultBehavior
 import org.eclipse.lsp4j.PrepareRenameParams
 import org.eclipse.lsp4j.PrepareRenameResult
+import org.eclipse.lsp4j.ProgressParams
 import org.eclipse.lsp4j.PublishDiagnosticsParams
 import org.eclipse.lsp4j.Range
 import org.eclipse.lsp4j.ReferenceParams
 import org.eclipse.lsp4j.RegistrationParams
 import org.eclipse.lsp4j.RenameParams
 import org.eclipse.lsp4j.ServerCapabilities
+import org.eclipse.lsp4j.SetTraceParams
 import org.eclipse.lsp4j.ShowMessageRequestParams
 import org.eclipse.lsp4j.SignatureHelp
 import org.eclipse.lsp4j.SignatureHelpParams
@@ -94,9 +97,12 @@ import org.eclipse.lsp4j.TextEdit
 import org.eclipse.lsp4j.TypeDefinitionParams
 import org.eclipse.lsp4j.UnregistrationParams
 import org.eclipse.lsp4j.WillSaveTextDocumentParams
+import org.eclipse.lsp4j.WorkDoneProgressCancelParams
+import org.eclipse.lsp4j.WorkDoneProgressCreateParams
 import org.eclipse.lsp4j.WorkspaceEdit
 import org.eclipse.lsp4j.WorkspaceSymbol
 import org.eclipse.lsp4j.WorkspaceSymbolParams
+import org.eclipse.lsp4j.jsonrpc.Endpoint
 import org.eclipse.lsp4j.jsonrpc.messages.Either
 import org.eclipse.lsp4j.jsonrpc.messages.Either3
 import org.eclipse.lsp4j.services.LanguageClient
@@ -163,6 +169,67 @@ class DefaultRequestManager(
 
     override fun publishDiagnostics(publishDiagnosticsParams: PublishDiagnosticsParams) {
         client.publishDiagnostics(publishDiagnosticsParams)
+    }
+
+    override fun logTrace(params: LogTraceParams) {
+        client.logTrace(params)
+    }
+
+    override fun setTrace(params: SetTraceParams) {
+        if (checkStatus()) {
+            try {
+                server.setTrace(params)
+            } catch (e: Exception) {
+                crashed(e)
+            }
+        }
+    }
+
+    override fun notifyProgress(params: ProgressParams) {
+        client.notifyProgress(params)
+    }
+
+    override fun createProgress(params: WorkDoneProgressCreateParams): CompletableFuture<Void> {
+        return client.createProgress(params)
+    }
+
+    override fun cancelProgress(params: WorkDoneProgressCancelParams) {
+        if (checkStatus()) {
+            try {
+                server.cancelProgress(params)
+            } catch (e: Exception) {
+                crashed(e)
+            }
+        }
+    }
+
+    override fun notify(method: String, parameter: Any?) {
+        if (checkStatus()) {
+            try {
+                (server as? Endpoint)?.notify(method, parameter)
+            } catch (e: Exception) {
+                crashed(e)
+            }
+        }
+    }
+
+    override fun request(method: String, parameter: Any?): CompletableFuture<*> {
+        return if (checkStatus()) {
+            try {
+                (server as? Endpoint)?.request(method, parameter) ?: CompletableFuture<Any>().apply {
+                    completeExceptionally(UnsupportedOperationException("Unsupported request: $method"))
+                }
+            } catch (e: Exception) {
+                crashed(e)
+                CompletableFuture<Any>().apply {
+                    completeExceptionally(e)
+                }
+            }
+        } else {
+            CompletableFuture<Any>().apply {
+                completeExceptionally(UnsupportedOperationException("Server not initialized"))
+            }
+        }
     }
 
     // Server

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/client/languageserver/requestmanager/RequestManager.kt
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/client/languageserver/requestmanager/RequestManager.kt
@@ -65,11 +65,13 @@ import org.eclipse.lsp4j.InitializeResult
 import org.eclipse.lsp4j.InitializedParams
 import org.eclipse.lsp4j.Location
 import org.eclipse.lsp4j.LocationLink
+import org.eclipse.lsp4j.LogTraceParams
 import org.eclipse.lsp4j.MessageActionItem
 import org.eclipse.lsp4j.MessageParams
 import org.eclipse.lsp4j.PrepareRenameDefaultBehavior
 import org.eclipse.lsp4j.PrepareRenameParams
 import org.eclipse.lsp4j.PrepareRenameResult
+import org.eclipse.lsp4j.ProgressParams
 import org.eclipse.lsp4j.PublishDiagnosticsParams
 import org.eclipse.lsp4j.Range
 import org.eclipse.lsp4j.ReferenceParams
@@ -80,6 +82,7 @@ import org.eclipse.lsp4j.SemanticTokensDelta
 import org.eclipse.lsp4j.SemanticTokensDeltaParams
 import org.eclipse.lsp4j.SemanticTokensParams
 import org.eclipse.lsp4j.SemanticTokensRangeParams
+import org.eclipse.lsp4j.SetTraceParams
 import org.eclipse.lsp4j.ShowMessageRequestParams
 import org.eclipse.lsp4j.SignatureHelp
 import org.eclipse.lsp4j.SignatureHelpParams
@@ -91,6 +94,9 @@ import org.eclipse.lsp4j.UnregistrationParams
 import org.eclipse.lsp4j.WillSaveTextDocumentParams
 import org.eclipse.lsp4j.WorkspaceEdit
 import org.eclipse.lsp4j.ServerCapabilities
+import org.eclipse.lsp4j.WorkDoneProgressCancelParams
+import org.eclipse.lsp4j.WorkDoneProgressCreateParams
+import org.eclipse.lsp4j.jsonrpc.Endpoint
 import org.eclipse.lsp4j.jsonrpc.messages.Either
 import org.eclipse.lsp4j.jsonrpc.messages.Either3
 import org.eclipse.lsp4j.services.LanguageClient
@@ -109,7 +115,7 @@ import java.util.concurrent.CompletableFuture
  *
  */
 abstract class RequestManager : LanguageClient, TextDocumentService, WorkspaceService,
-    LanguageServer {
+    LanguageServer, Endpoint {
 
     abstract val capabilities: ServerCapabilities?
     abstract val serverName: String
@@ -192,5 +198,10 @@ abstract class RequestManager : LanguageClient, TextDocumentService, WorkspaceSe
     override fun semanticTokensRange(params: SemanticTokensRangeParams): CompletableFuture<SemanticTokens> {
         return super.semanticTokensRange(params)
     }
+    abstract override fun logTrace(params: LogTraceParams)
+    abstract override fun setTrace(params: SetTraceParams)
+    abstract override fun notifyProgress(params: ProgressParams)
+    abstract override fun createProgress(params: WorkDoneProgressCreateParams): CompletableFuture<Void>
+    abstract override fun cancelProgress(params: WorkDoneProgressCancelParams)
 }
 

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/client/languageserver/wrapper/EventHandler.kt
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/client/languageserver/wrapper/EventHandler.kt
@@ -28,10 +28,15 @@ import io.github.rosemoe.sora.lsp.client.languageserver.ServerInitializeListener
 import io.github.rosemoe.sora.lsp.client.languageserver.ServerStatus
 import io.github.rosemoe.sora.lsp.events.AsyncEventListener
 import org.eclipse.lsp4j.InitializeResult
+import org.eclipse.lsp4j.LogTraceParams
 import org.eclipse.lsp4j.MessageParams
+import org.eclipse.lsp4j.ProgressParams
+import org.eclipse.lsp4j.WorkDoneProgressCreateParams
+import org.eclipse.lsp4j.jsonrpc.Endpoint
 import org.eclipse.lsp4j.jsonrpc.MessageConsumer
 import org.eclipse.lsp4j.jsonrpc.messages.Message
 import org.eclipse.lsp4j.services.LanguageServer
+import java.util.concurrent.CompletableFuture
 import java.util.function.BooleanSupplier
 import java.util.function.Function
 
@@ -41,9 +46,10 @@ import java.util.function.Function
 class EventHandler internal constructor(
     internal val listener: EventListener,
     private val isRunning: BooleanSupplier
-) :
-    Function<MessageConsumer, MessageConsumer> {
+) : Function<MessageConsumer, MessageConsumer> {
+
     private var languageServer: LanguageServer? = null
+
     override fun apply(messageConsumer: MessageConsumer): MessageConsumer {
         return MessageConsumer { message: Message ->
             if (isRunning.asBoolean) {
@@ -56,13 +62,27 @@ class EventHandler internal constructor(
         this.languageServer = languageServer
     }
 
-    interface EventListener : ServerInitializeListener {
+    interface EventListener : ServerInitializeListener, Endpoint {
         override fun initialize(server: LanguageServer?, result: InitializeResult) {}
         fun onStatusChange(newStatus: ServerStatus, oldStatus: ServerStatus) {}
         fun onHandlerException(exception: Exception) {}
         fun onEventException(eventListener: AsyncEventListener, exception: Exception) {}
-        fun onShowMessage(messageParams: MessageParams?) {}
-        fun onLogMessage(messageParams: MessageParams?) {}
+        fun onShowMessage(messageParams: MessageParams) {}
+        fun onLogMessage(messageParams: MessageParams) {}
+        fun onProgress(params: ProgressParams) {}
+        fun onLogTrace(params: LogTraceParams) {}
+        fun onWorkDoneProgressCreate(params: WorkDoneProgressCreateParams) {}
+
+        override fun notify(method: String, parameter: Any?) {}
+        override fun request(method: String, parameter: Any?): CompletableFuture<*>? {
+            val future = CompletableFuture<Any>()
+            future.completeExceptionally(
+                UnsupportedOperationException(
+                    "Unsupported request: $method"
+                )
+            )
+            return future
+        }
 
         companion object {
             val DEFAULT: EventListener = object : EventListener {}

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/client/languageserver/wrapper/LanguageServerWrapper.kt
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/client/languageserver/wrapper/LanguageServerWrapper.kt
@@ -92,7 +92,8 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
 
 class LanguageServerWrapper(
-    val serverDefinition: LanguageServerDefinition, val project: LspProject
+    val serverDefinition: LanguageServerDefinition,
+    val project: LspProject
 ) {
     private val TAG = "LanguageServerWrapper"
     val serverName = serverDefinition.name
@@ -130,6 +131,10 @@ class LanguageServerWrapper(
 
     fun reportEventException(eventListener: AsyncEventListener, exception: Exception) {
         eventHandler?.listener?.onEventException(eventListener, exception)
+    }
+
+    fun getCachedServerCapabilities(): ServerCapabilities? {
+        return effectiveCapabilities ?: initializeResult?.capabilities
     }
 
     /**
@@ -282,7 +287,7 @@ class LanguageServerWrapper(
         }
     }
 
-    /*
+    /**
      * The shutdown request is sent from the client to the server. It asks the server to shut down, but to not exit \
      * (otherwise the response might not be delivered correctly to the client).
      * Only if the exit flag is true, particular server instance will exit.

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/editor/LspEditor.kt
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/editor/LspEditor.kt
@@ -35,6 +35,12 @@ import io.github.rosemoe.sora.lsp.events.diagnostics.publishDiagnostics
 import io.github.rosemoe.sora.lsp.events.document.documentClose
 import io.github.rosemoe.sora.lsp.events.document.documentOpen
 import io.github.rosemoe.sora.lsp.events.document.documentSave
+import io.github.rosemoe.sora.lsp.events.navigation.definition
+import io.github.rosemoe.sora.lsp.events.navigation.references
+import io.github.rosemoe.sora.lsp.events.progress.cancelProgress
+import io.github.rosemoe.sora.lsp.events.rename.prepareRename
+import io.github.rosemoe.sora.lsp.events.rename.rename
+import io.github.rosemoe.sora.lsp.events.workspace.setTrace
 import io.github.rosemoe.sora.lsp.requests.Timeout
 import io.github.rosemoe.sora.lsp.requests.Timeouts
 import io.github.rosemoe.sora.lsp.utils.FileUri
@@ -52,11 +58,19 @@ import org.eclipse.lsp4j.Command
 import org.eclipse.lsp4j.Diagnostic
 import org.eclipse.lsp4j.DocumentHighlight
 import org.eclipse.lsp4j.Hover
+import org.eclipse.lsp4j.Location
+import org.eclipse.lsp4j.LocationLink
+import org.eclipse.lsp4j.Position
+import org.eclipse.lsp4j.PrepareRenameDefaultBehavior
+import org.eclipse.lsp4j.PrepareRenameResult
 import org.eclipse.lsp4j.Range
 import org.eclipse.lsp4j.SignatureHelp
 import org.eclipse.lsp4j.TextDocumentSyncKind
+import org.eclipse.lsp4j.WorkspaceEdit
 import org.eclipse.lsp4j.jsonrpc.messages.Either
+import org.eclipse.lsp4j.jsonrpc.messages.Either3
 import java.lang.ref.WeakReference
+import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeoutException
 
 class LspEditor(
@@ -330,6 +344,146 @@ class LspEditor(
     @WorkerThread
     fun saveDocumentBlocking() = runBlocking {
         saveDocument()
+    }
+
+    /**
+     * Request the definition of the symbol at the given position
+     */
+    suspend fun requestDefinition(position: Position?): Either<List<Location>, List<LocationLink>>? {
+        return eventManager.emitAsync(EventType.definition) {
+            put(position)
+        }.getOrNull("result")
+    }
+
+    /**
+     * Request the definition of the symbol at the given position
+     */
+    suspend fun requestDefinition(position: CharPosition): Either<List<Location>, List<LocationLink>>? {
+        return eventManager.emitAsync(EventType.definition) {
+            put(position)
+        }.getOrNull("result")
+    }
+
+    /**
+     * Request the definition of the symbol at the current cursor position
+     */
+    suspend fun requestDefinition(): Either<List<Location>, List<LocationLink>>? {
+        return eventManager.emitAsync(EventType.definition).getOrNull("result")
+    }
+
+    /**
+     * Request the references of the symbol at the given position
+     */
+    suspend fun requestReferences(position: Position?, includeDeclaration: Boolean = true): List<Location?>? {
+        return eventManager.emitAsync(EventType.references) {
+            put(position)
+            put("includeDeclaration", includeDeclaration)
+        }.getOrNull("result")
+    }
+
+    /**
+     * Request the references of the symbol at the given position
+     */
+    suspend fun requestReferences(position: CharPosition, includeDeclaration: Boolean = true): List<Location?>? {
+        return eventManager.emitAsync(EventType.references) {
+            put(position)
+            put("includeDeclaration", includeDeclaration)
+        }.getOrNull("result")
+    }
+
+    /**
+     * Request the references of the symbol at the current cursor position
+     */
+    suspend fun requestReferences(includeDeclaration: Boolean = true): List<Location?>? {
+        return eventManager.emitAsync(EventType.references) {
+            put("includeDeclaration", includeDeclaration)
+        }.getOrNull("result")
+    }
+
+    /**
+     * Request the prepare rename of the symbol at the given position
+     */
+    suspend fun requestPrepareRename(position: Position?): Either3<Range, PrepareRenameResult, PrepareRenameDefaultBehavior>? {
+        return eventManager.emitAsync(EventType.prepareRename) {
+            put(position)
+        }.getOrNull("result")
+    }
+
+    /**
+     * Request the prepare rename of the symbol at the given position
+     */
+    suspend fun requestPrepareRename(position: CharPosition): Either3<Range, PrepareRenameResult, PrepareRenameDefaultBehavior>? {
+        return eventManager.emitAsync(EventType.prepareRename) {
+            put(position)
+        }.getOrNull("result")
+    }
+
+    /**
+     * Request the prepare rename of the symbol at the current cursor position
+     */
+    suspend fun requestPrepareRename(): Either3<Range, PrepareRenameResult, PrepareRenameDefaultBehavior>? {
+        return eventManager.emitAsync(EventType.prepareRename).getOrNull("result")
+    }
+
+    /**
+     * Request the rename of the symbol at the given position
+     */
+    suspend fun requestRename(newName: String, position: Position?): WorkspaceEdit? {
+        return eventManager.emitAsync(EventType.rename) {
+            put("newName", newName)
+            put(position)
+        }.getOrNull("result")
+    }
+
+    /**
+     * Request the rename of the symbol at the given position
+     */
+    suspend fun requestRename(newName: String, position: CharPosition): WorkspaceEdit? {
+        return eventManager.emitAsync(EventType.rename) {
+            put("newName", newName)
+            put(position)
+        }.getOrNull("result")
+    }
+
+    /**
+     * Request the rename of the symbol at the current cursor position
+     */
+    suspend fun requestRename(newName: String): WorkspaceEdit? {
+        return eventManager.emitAsync(EventType.rename) {
+            put("newName", newName)
+        }.getOrNull("result")
+    }
+
+    /**
+     * Cancel a progress operation on the server
+     */
+    suspend fun cancelProgress(token: Either<String, Int>) {
+        eventManager.emitAsync(EventType.cancelProgress) {
+            put("token", token)
+        }
+    }
+
+    /**
+     * Set the trace setting of the server
+     */
+    suspend fun setTrace(value: String) {
+        eventManager.emitAsync(EventType.setTrace) {
+            put("value", value)
+        }
+    }
+
+    /**
+     * Send a custom notification to the server
+     */
+    fun notify(method: String, parameter: Any?) {
+        requestManager.notify(method, parameter)
+    }
+
+    /**
+     * Send a custom request to the server
+     */
+    fun request(method: String, parameter: Any?): CompletableFuture<*> {
+        return requestManager.request(method, parameter)
     }
 
     fun onDiagnosticsUpdate() {

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/editor/LspProject.kt
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/editor/LspProject.kt
@@ -44,9 +44,15 @@ import io.github.rosemoe.sora.lsp.events.format.RangeFormattingEvent
 import io.github.rosemoe.sora.lsp.events.highlight.DocumentHighlightEvent
 import io.github.rosemoe.sora.lsp.events.hover.HoverEvent
 import io.github.rosemoe.sora.lsp.events.inlayhint.InlayHintEvent
+import io.github.rosemoe.sora.lsp.events.navigation.DefinitionEvent
+import io.github.rosemoe.sora.lsp.events.navigation.ReferencesEvent
+import io.github.rosemoe.sora.lsp.events.progress.CancelProgressEvent
+import io.github.rosemoe.sora.lsp.events.rename.PrepareRenameEvent
+import io.github.rosemoe.sora.lsp.events.rename.RenameEvent
 import io.github.rosemoe.sora.lsp.events.signature.SignatureHelpEvent
 import io.github.rosemoe.sora.lsp.events.workspace.WorkSpaceApplyEditEvent
 import io.github.rosemoe.sora.lsp.events.workspace.WorkSpaceExecuteCommand
+import io.github.rosemoe.sora.lsp.events.workspace.SetTraceEvent
 import io.github.rosemoe.sora.lsp.utils.FileUri
 import io.github.rosemoe.sora.lsp.utils.toFileUri
 import kotlinx.coroutines.CoroutineScope
@@ -199,7 +205,9 @@ class LspProject(
             ::DocumentOpenEvent, ::HoverEvent, ::CodeActionEvent,
             ::WorkSpaceApplyEditEvent, ::WorkSpaceExecuteCommand,
             ::InlayHintEvent, ::DocumentHighlightEvent,
-            ::DocumentColorEvent
+            ::DocumentColorEvent, ::DefinitionEvent, ::ReferencesEvent,
+            ::PrepareRenameEvent, ::RenameEvent, ::CancelProgressEvent,
+            ::SetTraceEvent
         )
 
         events.forEach {

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/events/code/CodeActionEvent.kt
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/events/code/CodeActionEvent.kt
@@ -47,7 +47,7 @@ import java.util.concurrent.CompletableFuture
 class CodeActionEvent : AsyncEventListener() {
     override val eventName: String = EventType.codeAction
 
-    var future: CompletableFuture<Void>? = null
+    var future: CompletableFuture<*>? = null
 
     override val isAsync = true
 
@@ -67,7 +67,7 @@ class CodeActionEvent : AsyncEventListener() {
 
         val future = requestManager.codeAction(codeActionParams) ?: return@withContext
 
-        this@CodeActionEvent.future = future.thenAccept { }
+        this@CodeActionEvent.future = future
 
         var codeActions: List<Either<Command, CodeAction>>? = null
 

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/events/color/DocumentColor.kt
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/events/color/DocumentColor.kt
@@ -47,13 +47,14 @@ import org.eclipse.lsp4j.ColorInformation
 import org.eclipse.lsp4j.DocumentColorParams
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentHashMap
+import kotlin.time.Duration.Companion.milliseconds
 
 @OptIn(FlowPreview::class)
 @Experimental
 class DocumentColorEvent : AsyncEventListener() {
     override val eventName: String = EventType.documentColor
 
-    var future: CompletableFuture<Void>? = null
+    var future: CompletableFuture<*>? = null
 
     override val isAsync = true
 
@@ -78,7 +79,7 @@ class DocumentColorEvent : AsyncEventListener() {
 
             coroutineScope.launch(Dispatchers.Main) {
                 flow
-                    .debounce(50)
+                    .debounce(50.milliseconds)
                     .collect { request ->
                         processDocumentColorRequest(request, context)
                     }
@@ -109,7 +110,7 @@ class DocumentColorEvent : AsyncEventListener() {
                 requestManager.documentColor(DocumentColorParams(request.uri.createTextDocumentIdentifier()))
                     ?: return@withContext
 
-            this@DocumentColorEvent.future = future.thenAccept { }
+            this@DocumentColorEvent.future = future
 
             val documentColors: List<ColorInformation>?
 

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/events/diagnostics/QueryDocumentDiagnosticsEvent.kt
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/events/diagnostics/QueryDocumentDiagnosticsEvent.kt
@@ -38,7 +38,7 @@ import java.util.concurrent.CompletableFuture
 class QueryDocumentDiagnosticsEvent : AsyncEventListener() {
     override val eventName = EventType.queryDocumentDiagnostics
 
-    var future: CompletableFuture<Void>? = null
+    var future: CompletableFuture<*>? = null
 
     override suspend fun doHandleAsync(context: EventContext) {
         val editor = context.get<LspEditor>("lsp-editor")
@@ -51,7 +51,7 @@ class QueryDocumentDiagnosticsEvent : AsyncEventListener() {
                 // break if server don't support this capability
             ) ?: return
 
-        this.future = future.thenAccept { }
+        this.future = future
 
 
         // If return null, create an empty report

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/events/format/FullFormattingEvent.kt
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/events/format/FullFormattingEvent.kt
@@ -43,10 +43,13 @@ import kotlinx.coroutines.withTimeout
 import org.eclipse.lsp4j.DocumentFormattingParams
 import org.eclipse.lsp4j.FormattingOptions
 import org.eclipse.lsp4j.TextEdit
+import java.util.concurrent.CompletableFuture
 
 
 class FullFormattingEvent : AsyncEventListener() {
     override val eventName = EventType.fullFormatting
+
+    var future: CompletableFuture<*>? = null
 
     override suspend fun doHandleAsync(context: EventContext) {
         val editor = context.get<LspEditor>("lsp-editor")
@@ -63,6 +66,8 @@ class FullFormattingEvent : AsyncEventListener() {
             editor.uri.createTextDocumentIdentifier()
 
         val formattingFuture = requestManager.formatting(formattingParams) ?: return
+
+        future = formattingFuture
 
         val textEditList: List<TextEdit>
 
@@ -84,6 +89,11 @@ class FullFormattingEvent : AsyncEventListener() {
             it.reportEventException(this, exception)
         }
         throw LSPException("Formatting code timeout", exception)
+    }
+
+    override fun dispose() {
+        future?.cancel(true)
+        future = null
     }
 }
 

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/events/format/RangeFormattingEvent.kt
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/events/format/RangeFormattingEvent.kt
@@ -44,9 +44,12 @@ import kotlinx.coroutines.withTimeout
 import org.eclipse.lsp4j.DocumentRangeFormattingParams
 import org.eclipse.lsp4j.FormattingOptions
 import org.eclipse.lsp4j.TextEdit
+import java.util.concurrent.CompletableFuture
 
 class RangeFormattingEvent : AsyncEventListener() {
     override val eventName = EventType.rangeFormatting
+
+    var future: CompletableFuture<*>? = null
 
     override suspend fun doHandleAsync(context: EventContext) {
         val editor = context.get<LspEditor>("lsp-editor")
@@ -68,6 +71,8 @@ class RangeFormattingEvent : AsyncEventListener() {
 
         val formattingFuture = requestManager.rangeFormatting(formattingParams) ?: return
 
+        future = formattingFuture
+
         val textEditList: List<TextEdit>
 
         withTimeout(Timeout[Timeouts.FORMATTING, editor].toLong()) {
@@ -88,6 +93,11 @@ class RangeFormattingEvent : AsyncEventListener() {
             it.reportEventException(this, exception)
         }
         throw LSPException("Formatting code timeout", exception)
+    }
+
+    override fun dispose() {
+        future?.cancel(true)
+        future = null
     }
 }
 

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/events/highlight/DocumentHighlightEvent.kt
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/events/highlight/DocumentHighlightEvent.kt
@@ -32,6 +32,7 @@ import io.github.rosemoe.sora.lsp.events.getByClass
 import io.github.rosemoe.sora.lsp.requests.Timeout
 import io.github.rosemoe.sora.lsp.requests.Timeouts
 import io.github.rosemoe.sora.lsp.utils.asLspPosition
+import io.github.rosemoe.sora.lsp.utils.createPosition
 import io.github.rosemoe.sora.lsp.utils.createTextDocumentIdentifier
 import io.github.rosemoe.sora.text.CharPosition
 import kotlinx.coroutines.Dispatchers
@@ -40,12 +41,13 @@ import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import org.eclipse.lsp4j.DocumentHighlight
 import org.eclipse.lsp4j.DocumentHighlightParams
+import org.eclipse.lsp4j.Position
 import java.util.concurrent.CompletableFuture
 
 class DocumentHighlightEvent : AsyncEventListener() {
     override val eventName: String = EventType.documentHighlight
 
-    var future: CompletableFuture<Void>? = null
+    var future: CompletableFuture<*>? = null
 
     override val isAsync = true
 
@@ -55,18 +57,23 @@ class DocumentHighlightEvent : AsyncEventListener() {
 
     override suspend fun doHandleAsync(context: EventContext) = withContext(Dispatchers.IO) {
         val editor = context.get<LspEditor>("lsp-editor")
-        val request = context.getByClass<DocumentHighlightRequest>() ?: return@withContext
+
+        val position = context.getByClass<Position>()
+            ?: context.getByClass<CharPosition>()?.asLspPosition()
+            ?: context.getByClass<DocumentHighlightRequest>()?.selectionStart?.asLspPosition()
+            ?: editor.editor?.let { createPosition(it.cursor.leftLine, it.cursor.leftColumn) }
+            ?: return@withContext
 
         val requestManager = editor.requestManager
 
         val params = DocumentHighlightParams(
             editor.uri.createTextDocumentIdentifier(),
-            request.selectionStart.asLspPosition()
+            position
         )
 
         val future = requestManager.documentHighlight(params) ?: return@withContext
 
-        this@DocumentHighlightEvent.future = future.thenAccept { }
+        this@DocumentHighlightEvent.future = future
 
         val documentHighlights: List<DocumentHighlight>?
 
@@ -75,6 +82,7 @@ class DocumentHighlightEvent : AsyncEventListener() {
         }
 
         editor.showDocumentHighlight(documentHighlights)
+        context.put("result", documentHighlights)
     }
 
     override fun dispose() {

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/events/hover/HoverEvent.kt
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/events/hover/HoverEvent.kt
@@ -32,6 +32,7 @@ import io.github.rosemoe.sora.lsp.events.getByClass
 import io.github.rosemoe.sora.lsp.requests.Timeout
 import io.github.rosemoe.sora.lsp.requests.Timeouts
 import io.github.rosemoe.sora.lsp.utils.asLspPosition
+import io.github.rosemoe.sora.lsp.utils.createPosition
 import io.github.rosemoe.sora.lsp.utils.createTextDocumentIdentifier
 import io.github.rosemoe.sora.text.CharPosition
 import kotlinx.coroutines.Dispatchers
@@ -40,29 +41,34 @@ import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import org.eclipse.lsp4j.Hover
 import org.eclipse.lsp4j.HoverParams
+import org.eclipse.lsp4j.Position
 import java.util.concurrent.CompletableFuture
 
 class HoverEvent : AsyncEventListener() {
     override val eventName: String = EventType.hover
 
-    var future: CompletableFuture<Void>? = null
+    var future: CompletableFuture<*>? = null
 
     override val isAsync = true
 
     override suspend fun doHandleAsync(context: EventContext) = withContext(Dispatchers.IO) {
         val editor = context.get<LspEditor>("lsp-editor")
-        val position = context.getByClass<CharPosition>() ?: return@withContext
+
+        val position = context.getByClass<Position>()
+            ?: context.getByClass<CharPosition>()?.asLspPosition()
+            ?: editor.editor?.let { createPosition(it.cursor.leftLine, it.cursor.leftColumn) }
+            ?: return@withContext
 
         val requestManager = editor.requestManager
 
         val hoverParams = HoverParams(
             editor.uri.createTextDocumentIdentifier(),
-            position.asLspPosition()
+            position
         )
 
         val future = requestManager.hover(hoverParams) ?: return@withContext
 
-        this@HoverEvent.future = future.thenAccept { }
+        this@HoverEvent.future = future
 
         val hover: Hover?
 
@@ -71,6 +77,7 @@ class HoverEvent : AsyncEventListener() {
         }
 
         editor.showHover(hover)
+        context.put("result", hover)
     }
 
     override fun dispose() {

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/events/inlayhint/InlayHintEvent.kt
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/events/inlayhint/InlayHintEvent.kt
@@ -57,7 +57,7 @@ import kotlin.math.min
 class InlayHintEvent : AsyncEventListener() {
     override val eventName: String = EventType.inlayHint
 
-    var future: CompletableFuture<Void>? = null
+    var future: CompletableFuture<*>? = null
 
     override val isAsync = true
 
@@ -130,7 +130,7 @@ class InlayHintEvent : AsyncEventListener() {
 
             val future = requestManager.inlayHint(inlayHintParams) ?: return@withContext
 
-            this@InlayHintEvent.future = future.thenAccept { }
+            this@InlayHintEvent.future = future
 
             val inlayHints: List<InlayHint>?
 

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/events/navigation/DefinitionEvent.kt
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/events/navigation/DefinitionEvent.kt
@@ -1,7 +1,7 @@
 /*******************************************************************************
  *    sora-editor - the awesome code editor for Android
  *    https://github.com/Rosemoe/sora-editor
- *    Copyright (C) 2020-2023  Rosemoe
+ *    Copyright (C) 2020-2026  Rosemoe
  *
  *     This library is free software; you can redistribute it and/or
  *     modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,7 @@
  *     additional information or have any questions
  ******************************************************************************/
 
-package io.github.rosemoe.sora.lsp.events.workspace
+package io.github.rosemoe.sora.lsp.events.navigation
 
 import io.github.rosemoe.sora.lsp.editor.LspEditor
 import io.github.rosemoe.sora.lsp.events.AsyncEventListener
@@ -30,34 +30,41 @@ import io.github.rosemoe.sora.lsp.events.EventContext
 import io.github.rosemoe.sora.lsp.events.EventType
 import io.github.rosemoe.sora.lsp.requests.Timeout
 import io.github.rosemoe.sora.lsp.requests.Timeouts
+import io.github.rosemoe.sora.lsp.events.getByClass
+import io.github.rosemoe.sora.lsp.utils.asLspPosition
+import io.github.rosemoe.sora.lsp.utils.createPosition
+import io.github.rosemoe.sora.lsp.utils.createTextDocumentIdentifier
+import io.github.rosemoe.sora.text.CharPosition
 import kotlinx.coroutines.future.await
 import kotlinx.coroutines.withTimeout
-import org.eclipse.lsp4j.ExecuteCommandParams
+import org.eclipse.lsp4j.DefinitionParams
+import org.eclipse.lsp4j.Position
 import java.util.concurrent.CompletableFuture
 
-class WorkSpaceExecuteCommand : AsyncEventListener() {
-    override val eventName: String = EventType.workSpaceExecuteCommand
-
-    override val isAsync = true
+class DefinitionEvent : AsyncEventListener() {
+    override val eventName = EventType.definition
 
     var future: CompletableFuture<*>? = null
 
     override suspend fun doHandleAsync(context: EventContext) {
-        val command = context.get<String>("command")
-        val args = context.get<List<Any>>("args")
-
         val editor = context.get<LspEditor>("lsp-editor")
-        val requestManager = editor.requestManager
-        val executeCommandParams = ExecuteCommandParams(command, args)
-        val future = requestManager.executeCommand(executeCommandParams)
 
-        this@WorkSpaceExecuteCommand.future = future
+        val position = context.getByClass<Position>()
+            ?: context.getByClass<CharPosition>()?.asLspPosition()
+            ?: editor.editor?.let { createPosition(it.cursor.leftLine, it.cursor.leftColumn) }
+            ?: return
 
-        val result: Any?
+        val params = DefinitionParams(
+            editor.uri.createTextDocumentIdentifier(),
+            position
+        )
 
-        withTimeout(Timeout[Timeouts.EXECUTE_COMMAND, editor].toLong()) {
-            result =
-                future?.await()
+        val requestFuture = editor.requestManager.definition(params) ?: return
+
+        future = requestFuture
+
+        val result = withTimeout(Timeout[Timeouts.DEFINITION, editor].toLong()) {
+            requestFuture.await()
         }
 
         context.put("result", result)
@@ -69,5 +76,5 @@ class WorkSpaceExecuteCommand : AsyncEventListener() {
     }
 }
 
-val EventType.workSpaceExecuteCommand: String
-    get() = "workspace/executeCommand"
+val EventType.definition: String
+    get() = "textDocument/definition"

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/events/navigation/ReferencesEvent.kt
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/events/navigation/ReferencesEvent.kt
@@ -1,7 +1,7 @@
 /*******************************************************************************
  *    sora-editor - the awesome code editor for Android
  *    https://github.com/Rosemoe/sora-editor
- *    Copyright (C) 2020-2023  Rosemoe
+ *    Copyright (C) 2020-2026  Rosemoe
  *
  *     This library is free software; you can redistribute it and/or
  *     modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,7 @@
  *     additional information or have any questions
  ******************************************************************************/
 
-package io.github.rosemoe.sora.lsp.events.workspace
+package io.github.rosemoe.sora.lsp.events.navigation
 
 import io.github.rosemoe.sora.lsp.editor.LspEditor
 import io.github.rosemoe.sora.lsp.events.AsyncEventListener
@@ -30,34 +30,45 @@ import io.github.rosemoe.sora.lsp.events.EventContext
 import io.github.rosemoe.sora.lsp.events.EventType
 import io.github.rosemoe.sora.lsp.requests.Timeout
 import io.github.rosemoe.sora.lsp.requests.Timeouts
+import io.github.rosemoe.sora.lsp.events.getByClass
+import io.github.rosemoe.sora.lsp.utils.asLspPosition
+import io.github.rosemoe.sora.lsp.utils.createPosition
+import io.github.rosemoe.sora.lsp.utils.createTextDocumentIdentifier
+import io.github.rosemoe.sora.text.CharPosition
 import kotlinx.coroutines.future.await
 import kotlinx.coroutines.withTimeout
-import org.eclipse.lsp4j.ExecuteCommandParams
+import org.eclipse.lsp4j.Position
+import org.eclipse.lsp4j.ReferenceContext
+import org.eclipse.lsp4j.ReferenceParams
 import java.util.concurrent.CompletableFuture
 
-class WorkSpaceExecuteCommand : AsyncEventListener() {
-    override val eventName: String = EventType.workSpaceExecuteCommand
-
-    override val isAsync = true
+class ReferencesEvent : AsyncEventListener() {
+    override val eventName = EventType.references
 
     var future: CompletableFuture<*>? = null
 
     override suspend fun doHandleAsync(context: EventContext) {
-        val command = context.get<String>("command")
-        val args = context.get<List<Any>>("args")
-
         val editor = context.get<LspEditor>("lsp-editor")
-        val requestManager = editor.requestManager
-        val executeCommandParams = ExecuteCommandParams(command, args)
-        val future = requestManager.executeCommand(executeCommandParams)
 
-        this@WorkSpaceExecuteCommand.future = future
+        val position = context.getByClass<Position>()
+            ?: context.getByClass<CharPosition>()?.asLspPosition()
+            ?: editor.editor?.let { createPosition(it.cursor.leftLine, it.cursor.leftColumn) }
+            ?: return
 
-        val result: Any?
+        val includeDeclaration = context.getOrDefault("includeDeclaration", true)
 
-        withTimeout(Timeout[Timeouts.EXECUTE_COMMAND, editor].toLong()) {
-            result =
-                future?.await()
+        val params = ReferenceParams(
+            editor.uri.createTextDocumentIdentifier(),
+            position,
+            ReferenceContext(includeDeclaration)
+        )
+
+        val requestFuture = editor.requestManager.references(params) ?: return
+
+        future = requestFuture
+
+        val result = withTimeout(Timeout[Timeouts.REFERENCES, editor].toLong()) {
+            requestFuture.await()
         }
 
         context.put("result", result)
@@ -69,5 +80,5 @@ class WorkSpaceExecuteCommand : AsyncEventListener() {
     }
 }
 
-val EventType.workSpaceExecuteCommand: String
-    get() = "workspace/executeCommand"
+val EventType.references: String
+    get() = "textDocument/references"

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/events/progress/CancelProgressEvent.kt
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/events/progress/CancelProgressEvent.kt
@@ -1,7 +1,7 @@
 /*******************************************************************************
  *    sora-editor - the awesome code editor for Android
  *    https://github.com/Rosemoe/sora-editor
- *    Copyright (C) 2020-2023  Rosemoe
+ *    Copyright (C) 2020-2026  Rosemoe
  *
  *     This library is free software; you can redistribute it and/or
  *     modify it under the terms of the GNU Lesser General Public
@@ -22,52 +22,25 @@
  *     additional information or have any questions
  ******************************************************************************/
 
-package io.github.rosemoe.sora.lsp.events.workspace
+package io.github.rosemoe.sora.lsp.events.progress
 
 import io.github.rosemoe.sora.lsp.editor.LspEditor
 import io.github.rosemoe.sora.lsp.events.AsyncEventListener
 import io.github.rosemoe.sora.lsp.events.EventContext
 import io.github.rosemoe.sora.lsp.events.EventType
-import io.github.rosemoe.sora.lsp.requests.Timeout
-import io.github.rosemoe.sora.lsp.requests.Timeouts
-import kotlinx.coroutines.future.await
-import kotlinx.coroutines.withTimeout
-import org.eclipse.lsp4j.ExecuteCommandParams
-import java.util.concurrent.CompletableFuture
+import org.eclipse.lsp4j.WorkDoneProgressCancelParams
+import org.eclipse.lsp4j.jsonrpc.messages.Either
 
-class WorkSpaceExecuteCommand : AsyncEventListener() {
-    override val eventName: String = EventType.workSpaceExecuteCommand
-
-    override val isAsync = true
-
-    var future: CompletableFuture<*>? = null
+class CancelProgressEvent : AsyncEventListener() {
+    override val eventName = EventType.cancelProgress
 
     override suspend fun doHandleAsync(context: EventContext) {
-        val command = context.get<String>("command")
-        val args = context.get<List<Any>>("args")
-
         val editor = context.get<LspEditor>("lsp-editor")
-        val requestManager = editor.requestManager
-        val executeCommandParams = ExecuteCommandParams(command, args)
-        val future = requestManager.executeCommand(executeCommandParams)
+        val token = context.get<Either<String, Int>>("token")
 
-        this@WorkSpaceExecuteCommand.future = future
-
-        val result: Any?
-
-        withTimeout(Timeout[Timeouts.EXECUTE_COMMAND, editor].toLong()) {
-            result =
-                future?.await()
-        }
-
-        context.put("result", result)
-    }
-
-    override fun dispose() {
-        future?.cancel(true)
-        future = null
+        editor.requestManager.cancelProgress(WorkDoneProgressCancelParams(token))
     }
 }
 
-val EventType.workSpaceExecuteCommand: String
-    get() = "workspace/executeCommand"
+val EventType.cancelProgress: String
+    get() = "window/workDoneProgress/cancel"

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/events/rename/PrepareRenameEvent.kt
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/events/rename/PrepareRenameEvent.kt
@@ -1,7 +1,7 @@
 /*******************************************************************************
  *    sora-editor - the awesome code editor for Android
  *    https://github.com/Rosemoe/sora-editor
- *    Copyright (C) 2020-2023  Rosemoe
+ *    Copyright (C) 2020-2026  Rosemoe
  *
  *     This library is free software; you can redistribute it and/or
  *     modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,7 @@
  *     additional information or have any questions
  ******************************************************************************/
 
-package io.github.rosemoe.sora.lsp.events.workspace
+package io.github.rosemoe.sora.lsp.events.rename
 
 import io.github.rosemoe.sora.lsp.editor.LspEditor
 import io.github.rosemoe.sora.lsp.events.AsyncEventListener
@@ -30,34 +30,41 @@ import io.github.rosemoe.sora.lsp.events.EventContext
 import io.github.rosemoe.sora.lsp.events.EventType
 import io.github.rosemoe.sora.lsp.requests.Timeout
 import io.github.rosemoe.sora.lsp.requests.Timeouts
+import io.github.rosemoe.sora.lsp.events.getByClass
+import io.github.rosemoe.sora.lsp.utils.asLspPosition
+import io.github.rosemoe.sora.lsp.utils.createPosition
+import io.github.rosemoe.sora.lsp.utils.createTextDocumentIdentifier
+import io.github.rosemoe.sora.text.CharPosition
 import kotlinx.coroutines.future.await
 import kotlinx.coroutines.withTimeout
-import org.eclipse.lsp4j.ExecuteCommandParams
+import org.eclipse.lsp4j.Position
+import org.eclipse.lsp4j.PrepareRenameParams
 import java.util.concurrent.CompletableFuture
 
-class WorkSpaceExecuteCommand : AsyncEventListener() {
-    override val eventName: String = EventType.workSpaceExecuteCommand
-
-    override val isAsync = true
+class PrepareRenameEvent : AsyncEventListener() {
+    override val eventName = EventType.prepareRename
 
     var future: CompletableFuture<*>? = null
 
     override suspend fun doHandleAsync(context: EventContext) {
-        val command = context.get<String>("command")
-        val args = context.get<List<Any>>("args")
-
         val editor = context.get<LspEditor>("lsp-editor")
-        val requestManager = editor.requestManager
-        val executeCommandParams = ExecuteCommandParams(command, args)
-        val future = requestManager.executeCommand(executeCommandParams)
 
-        this@WorkSpaceExecuteCommand.future = future
+        val position = context.getByClass<Position>()
+            ?: context.getByClass<CharPosition>()?.asLspPosition()
+            ?: editor.editor?.let { createPosition(it.cursor.leftLine, it.cursor.leftColumn) }
+            ?: return
 
-        val result: Any?
+        val params = PrepareRenameParams(
+            editor.uri.createTextDocumentIdentifier(),
+            position
+        )
 
-        withTimeout(Timeout[Timeouts.EXECUTE_COMMAND, editor].toLong()) {
-            result =
-                future?.await()
+        val requestFuture = editor.requestManager.prepareRename(params) ?: return
+
+        future = requestFuture
+
+        val result = withTimeout(Timeout[Timeouts.PREPARE_RENAME, editor].toLong()) {
+            requestFuture.await()
         }
 
         context.put("result", result)
@@ -69,5 +76,5 @@ class WorkSpaceExecuteCommand : AsyncEventListener() {
     }
 }
 
-val EventType.workSpaceExecuteCommand: String
-    get() = "workspace/executeCommand"
+val EventType.prepareRename: String
+    get() = "textDocument/prepareRename"

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/events/rename/RenameEvent.kt
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/events/rename/RenameEvent.kt
@@ -1,7 +1,7 @@
 /*******************************************************************************
  *    sora-editor - the awesome code editor for Android
  *    https://github.com/Rosemoe/sora-editor
- *    Copyright (C) 2020-2023  Rosemoe
+ *    Copyright (C) 2020-2026  Rosemoe
  *
  *     This library is free software; you can redistribute it and/or
  *     modify it under the terms of the GNU Lesser General Public
@@ -22,7 +22,7 @@
  *     additional information or have any questions
  ******************************************************************************/
 
-package io.github.rosemoe.sora.lsp.events.workspace
+package io.github.rosemoe.sora.lsp.events.rename
 
 import io.github.rosemoe.sora.lsp.editor.LspEditor
 import io.github.rosemoe.sora.lsp.events.AsyncEventListener
@@ -30,34 +30,44 @@ import io.github.rosemoe.sora.lsp.events.EventContext
 import io.github.rosemoe.sora.lsp.events.EventType
 import io.github.rosemoe.sora.lsp.requests.Timeout
 import io.github.rosemoe.sora.lsp.requests.Timeouts
+import io.github.rosemoe.sora.lsp.events.getByClass
+import io.github.rosemoe.sora.lsp.utils.asLspPosition
+import io.github.rosemoe.sora.lsp.utils.createPosition
+import io.github.rosemoe.sora.lsp.utils.createTextDocumentIdentifier
+import io.github.rosemoe.sora.text.CharPosition
 import kotlinx.coroutines.future.await
 import kotlinx.coroutines.withTimeout
-import org.eclipse.lsp4j.ExecuteCommandParams
+import org.eclipse.lsp4j.Position
+import org.eclipse.lsp4j.RenameParams
 import java.util.concurrent.CompletableFuture
 
-class WorkSpaceExecuteCommand : AsyncEventListener() {
-    override val eventName: String = EventType.workSpaceExecuteCommand
-
-    override val isAsync = true
+class RenameEvent : AsyncEventListener() {
+    override val eventName = EventType.rename
 
     var future: CompletableFuture<*>? = null
 
     override suspend fun doHandleAsync(context: EventContext) {
-        val command = context.get<String>("command")
-        val args = context.get<List<Any>>("args")
-
         val editor = context.get<LspEditor>("lsp-editor")
-        val requestManager = editor.requestManager
-        val executeCommandParams = ExecuteCommandParams(command, args)
-        val future = requestManager.executeCommand(executeCommandParams)
 
-        this@WorkSpaceExecuteCommand.future = future
+        val newName = context.get<String>("newName")
 
-        val result: Any?
+        val position = context.getByClass<Position>()
+            ?: context.getByClass<CharPosition>()?.asLspPosition()
+            ?: editor.editor?.let { createPosition(it.cursor.leftLine, it.cursor.leftColumn) }
+            ?: return
 
-        withTimeout(Timeout[Timeouts.EXECUTE_COMMAND, editor].toLong()) {
-            result =
-                future?.await()
+        val params = RenameParams(
+            editor.uri.createTextDocumentIdentifier(),
+            position,
+            newName
+        )
+
+        val requestFuture = editor.requestManager.rename(params) ?: return
+
+        future = requestFuture
+
+        val result = withTimeout(Timeout[Timeouts.RENAME, editor].toLong()) {
+            requestFuture.await()
         }
 
         context.put("result", result)
@@ -69,5 +79,5 @@ class WorkSpaceExecuteCommand : AsyncEventListener() {
     }
 }
 
-val EventType.workSpaceExecuteCommand: String
-    get() = "workspace/executeCommand"
+val EventType.rename: String
+    get() = "textDocument/rename"

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/events/signature/SignatureHelpEvent.kt
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/events/signature/SignatureHelpEvent.kt
@@ -45,7 +45,7 @@ import java.util.concurrent.CompletableFuture
 class SignatureHelpEvent : AsyncEventListener() {
     override val eventName: String = EventType.signatureHelp
 
-    var future: CompletableFuture<Void>? = null
+    var future: CompletableFuture<*>? = null
 
     override val isAsync = true
 
@@ -62,7 +62,7 @@ class SignatureHelpEvent : AsyncEventListener() {
 
         val future = requestManager.signatureHelp(signatureHelpParams) ?: return@withContext
 
-        this@SignatureHelpEvent.future = future.thenAccept { }
+        this@SignatureHelpEvent.future = future
 
         val signatureHelp: SignatureHelp?
 

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/events/workspace/SetTraceEvent.kt
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/events/workspace/SetTraceEvent.kt
@@ -1,7 +1,7 @@
 /*******************************************************************************
  *    sora-editor - the awesome code editor for Android
  *    https://github.com/Rosemoe/sora-editor
- *    Copyright (C) 2020-2023  Rosemoe
+ *    Copyright (C) 2020-2026  Rosemoe
  *
  *     This library is free software; you can redistribute it and/or
  *     modify it under the terms of the GNU Lesser General Public
@@ -28,46 +28,18 @@ import io.github.rosemoe.sora.lsp.editor.LspEditor
 import io.github.rosemoe.sora.lsp.events.AsyncEventListener
 import io.github.rosemoe.sora.lsp.events.EventContext
 import io.github.rosemoe.sora.lsp.events.EventType
-import io.github.rosemoe.sora.lsp.requests.Timeout
-import io.github.rosemoe.sora.lsp.requests.Timeouts
-import kotlinx.coroutines.future.await
-import kotlinx.coroutines.withTimeout
-import org.eclipse.lsp4j.ExecuteCommandParams
-import java.util.concurrent.CompletableFuture
+import org.eclipse.lsp4j.SetTraceParams
 
-class WorkSpaceExecuteCommand : AsyncEventListener() {
-    override val eventName: String = EventType.workSpaceExecuteCommand
-
-    override val isAsync = true
-
-    var future: CompletableFuture<*>? = null
+class SetTraceEvent : AsyncEventListener() {
+    override val eventName = EventType.setTrace
 
     override suspend fun doHandleAsync(context: EventContext) {
-        val command = context.get<String>("command")
-        val args = context.get<List<Any>>("args")
-
         val editor = context.get<LspEditor>("lsp-editor")
-        val requestManager = editor.requestManager
-        val executeCommandParams = ExecuteCommandParams(command, args)
-        val future = requestManager.executeCommand(executeCommandParams)
+        val value = context.get<String>("value")
 
-        this@WorkSpaceExecuteCommand.future = future
-
-        val result: Any?
-
-        withTimeout(Timeout[Timeouts.EXECUTE_COMMAND, editor].toLong()) {
-            result =
-                future?.await()
-        }
-
-        context.put("result", result)
-    }
-
-    override fun dispose() {
-        future?.cancel(true)
-        future = null
+        editor.requestManager.setTrace(SetTraceParams(value))
     }
 }
 
-val EventType.workSpaceExecuteCommand: String
-    get() = "workspace/executeCommand"
+val EventType.setTrace: String
+    get() = "$/setTrace"

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/requests/Timeout.kt
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/requests/Timeout.kt
@@ -41,6 +41,8 @@ enum class Timeouts(val defaultTimeout: Int) {
     INLAY_HINT(2000),
     INIT(10000),
     REFERENCES(2000),
+    RENAME(2000),
+    PREPARE_RENAME(1000),
     SIGNATURE(5000),
     SHUTDOWN(5000),
     SYMBOLS(2000),


### PR DESCRIPTION
This PR implements definition, rename, ... actions as LSP events (analog to already existing events). It also allows dynamic registration to handle custom requests and notifications.

Additionally, this PR fixes, that, for certain events, the future was saved with `thenAccept { }` instead of being assigned directly to the variable. This prevented the underlying future from being cancelled within the event's `dispose()` method.

## Changes List
- Implement new events for definition, references, rename, trace, and progress cancellation.
- Add high-level helper methods in `LspEditor` to easily request definitions, references, renames, progress cancellations, and traces.
- Integrate the LSP `Endpoint` interface across `RequestManager`, `AggregatedRequestManager`, and `DefaultLanguageClient` to support custom requests and notifications.
- Refactor asynchronous event listeners to store raw `CompletableFuture<*>` instead of mapping to `CompletableFuture<Void>`, enabling cancellation and proper disposal.