### PR TITLE
feat: use languageId in LspEditor

### DIFF
--- a/.idea/markdown.xml
+++ b/.idea/markdown.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="MarkdownSettings">
+    <option name="previewPanelProviderInfo">
+      <ProviderInfo name="Compose (experimental)" className="com.intellij.markdown.compose.preview.ComposePanelProvider" />
+    </option>
+  </component>
+</project>

--- a/app/src/main/java/io/github/rosemoe/sora/app/lsp/LspTestJavaActivity.java
+++ b/app/src/main/java/io/github/rosemoe/sora/app/lsp/LspTestJavaActivity.java
@@ -163,7 +163,7 @@ public class LspTestJavaActivity extends BaseEditorActivity {
         final Object lock = new Object();
 
         runOnUiThread(() -> {
-            lspEditor = lspProject.createEditor(projectPath + "/sample.lua");
+            lspEditor = lspProject.createEditor(projectPath + "/sample.lua",null);
 
             var wrapperLanguage = createTextMateLanguage();
             lspEditor.setWrapperLanguage(wrapperLanguage);

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/editor/LspEditor.kt
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/editor/LspEditor.kt
@@ -62,6 +62,7 @@ import java.util.concurrent.TimeoutException
 class LspEditor(
     val project: LspProject,
     val uri: FileUri,
+    val languageId: String? = null
 ) {
     private val delegate = LspEditorDelegate(this)
     internal val uiDelegate = LspEditorUIDelegate(this)
@@ -136,7 +137,7 @@ class LspEditor(
 
     val languageServerWrapper: LanguageServerWrapper
         get() = delegate.getPrimaryWrapper()
-            ?: throw IllegalStateException("No language server wrapper for extension $fileExt")
+            ?: throw IllegalStateException("No language server wrapper for language ${languageId ?: fileExt}")
 
     var diagnostics
         get() = project.diagnosticsContainer.getDiagnostics(uri)

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/editor/LspEditorDelegate.kt
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/editor/LspEditorDelegate.kt
@@ -19,8 +19,9 @@ internal class LspEditorDelegate(private val editor: LspEditor) {
     val aggregatedRequestManager = AggregatedRequestManager(emptySet())
 
     private fun refreshSessions() {
-        val definitions = editor.project.getServerDefinitions(editor.fileExt).ifEmpty {
-            editor.project.getServerDefinition(editor.fileExt)?.let { listOf(it) } ?: emptyList()
+        val language = editor.languageId ?: editor.fileExt
+        val definitions = editor.project.getServerDefinitions(language).ifEmpty {
+            editor.project.getServerDefinition(language)?.let { listOf(it) } ?: emptyList()
         }
 
         sessionInfos.removeAll { session ->

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/editor/LspProject.kt
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/editor/LspProject.kt
@@ -112,9 +112,9 @@ class LspProject(
             .distinctBy { it.name }
     }
 
-    fun createEditor(path: String): LspEditor {
+    fun createEditor(path: String, languageId: String? = null): LspEditor {
         val uri = FileUri(path)
-        val editor = LspEditor(this, uri)
+        val editor = LspEditor(this, uri, languageId)
         editors[uri] = editor
         return editor
     }
@@ -135,8 +135,8 @@ class LspProject(
         return editors[uri]
     }
 
-    fun getOrCreateEditor(path: String): LspEditor {
-        return getEditor(path) ?: createEditor(path)
+    fun getOrCreateEditor(path: String, languageId: String? = null): LspEditor {
+        return getEditor(path) ?: createEditor(path, languageId)
     }
 
     fun closeAllEditors() {

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/utils/LspUtils.kt
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/utils/LspUtils.kt
@@ -120,7 +120,7 @@ fun Range.asTextRange(): TextRange {
 fun LspEditor.createDidOpenTextDocumentParams(): DidOpenTextDocumentParams {
     val params = DidOpenTextDocumentParams()
     params.textDocument = TextDocumentItem(
-        this.uri.toFileUri(), this.fileExt, getVersion(this.uri), editorContent
+        this.uri.toFileUri(), this.languageId ?: this.fileExt, getVersion(this.uri), editorContent
     )
     return params
 }


### PR DESCRIPTION
Currently, there's no public API for creating an LspEditor with a custom `languageId`, and the LspUtils use the file extension as the `languageId`, which is suboptimal. Some LSP servers, such as Deno, only accept `"javascript"` as the languageId instead of `"js"`.

This PR provides a way to set a custom languageId