### PR TITLE
fix: add language ID support to language server definitions

### DIFF
--- a/app/src/main/java/io/github/rosemoe/sora/app/lsp/LspTestJavaActivity.java
+++ b/app/src/main/java/io/github/rosemoe/sora/app/lsp/LspTestJavaActivity.java
@@ -163,7 +163,7 @@ public class LspTestJavaActivity extends BaseEditorActivity {
         final Object lock = new Object();
 
         runOnUiThread(() -> {
-            lspEditor = lspProject.createEditor(projectPath + "/sample.lua",null);
+            lspEditor = lspProject.createEditor(projectPath + "/sample.lua", null);
 
             var wrapperLanguage = createTextMateLanguage();
             lspEditor.setWrapperLanguage(wrapperLanguage);

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/client/languageserver/serverdefinition/CustomLanguageServerDefinition.kt
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/client/languageserver/serverdefinition/CustomLanguageServerDefinition.kt
@@ -39,7 +39,8 @@ open class CustomLanguageServerDefinition @JvmOverloads constructor(
     serverConnectProvider: ServerConnectProvider,
     override val name: String = ext,
     private val expectedCapabilitiesOverride: ServerCapabilities? = null,
-    private val extensionsOverride: List<String>? = null
+    private val extensionsOverride: List<String>? = null,
+    override val languageId: String? = null
 ) : LanguageServerDefinition() {
 
     protected var serverConnectProvider: ServerConnectProvider

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/client/languageserver/serverdefinition/LanguageServerDefinition.kt
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/client/languageserver/serverdefinition/LanguageServerDefinition.kt
@@ -48,6 +48,8 @@ abstract class LanguageServerDefinition {
     open val exts: List<String>
         get() = listOf(ext)
 
+    open val languageId: String? = null
+
     open val name: String
         get() = ext
 

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/client/languageserver/serverdefinition/LanguageServerDefinitionDsl.kt
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/client/languageserver/serverdefinition/LanguageServerDefinitionDsl.kt
@@ -64,6 +64,7 @@ inline fun languageServerDefinition(
 class LanguageServerDefinitionDsl {
     private var extension: String? = null
     private var extensions: MutableList<String>? = null
+    private var languageId: String? = null
     private var serverName: String? = null
     private var expectedCapabilities: ServerCapabilities? = null
     private var connectProvider: CustomLanguageServerDefinition.ServerConnectProvider? = null
@@ -97,6 +98,10 @@ class LanguageServerDefinitionDsl {
      * Alias for [extensions].
      */
     fun exts(vararg values: String) = extensions(*values)
+
+    fun languageId(value: String) {
+        languageId = value
+    }
 
     /**
      * Overrides the user-facing name of the server definition.
@@ -153,7 +158,8 @@ class LanguageServerDefinitionDsl {
             connection,
             name = serverName ?: actualExtension,
             expectedCapabilitiesOverride = expectedCapabilities,
-            extensionsOverride = allExtensions
+            extensionsOverride = allExtensions,
+            languageId = languageId,
         ) {
             override val disabledFeatures: Set<LspFeature>
                 get() = this@LanguageServerDefinitionDsl.disabledFeatures

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/editor/LspEditorDelegate.kt
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/editor/LspEditorDelegate.kt
@@ -19,10 +19,11 @@ internal class LspEditorDelegate(private val editor: LspEditor) {
     val aggregatedRequestManager = AggregatedRequestManager(emptySet())
 
     private fun refreshSessions() {
-        val language = editor.languageId ?: editor.fileExt
-        val definitions = editor.project.getServerDefinitions(language).ifEmpty {
-            editor.project.getServerDefinition(language)?.let { listOf(it) } ?: emptyList()
-        }
+        val definitions =
+            editor.project.getServerDefinitions(
+                ext = editor.fileExt,
+                languageId = editor.languageId,
+            )
 
         sessionInfos.removeAll { session ->
             definitions.none { it.name == session.definition.name && it.ext == session.definition.ext }

--- a/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/editor/LspProject.kt
+++ b/editor-lsp/src/main/java/io/github/rosemoe/sora/lsp/editor/LspProject.kt
@@ -111,10 +111,11 @@ class LspProject(
         return definitions[ServerKey(ext, name ?: ext)]
     }
 
-    fun getServerDefinitions(ext: String): Collection<LanguageServerDefinition> {
-        return definitions.entries
-            .filter { it.key.ext == ext }
-            .map { it.value }
+    fun getServerDefinitions(ext: String, languageId: String? = null): Collection<LanguageServerDefinition> {
+        return definitions.values
+            .filter { definition ->
+                definition.ext == ext || (languageId != null && definition.languageId == languageId)
+            }
             .distinctBy { it.name }
     }
 


### PR DESCRIPTION
This PR fixes that the language server connection was no longer established when a `languageId` was specified in the LspEditor.
Regression from #881 